### PR TITLE
Replaced ref to `github:foliojs/brotli.js` by latest npm version in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@webrecorder/wombat": "^3.3.9",
     "auto-js-ipfs": "^1.3.10",
     "base64-js": "^1.5.1",
-    "brotli": "github:foliojs/brotli.js",
+    "brotli": "^1.3.3",
     "buffer": "^6.0.3",
     "fast-xml-parser": "^3.19.0",
     "format-link-header": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1052,9 +1052,10 @@ braces@^3.0.1, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-"brotli@github:foliojs/brotli.js":
-  version "1.3.2"
-  resolved "https://codeload.github.com/foliojs/brotli.js/tar.gz/919ce10e3ee8fa598d3b918b4d3bdd0dcda68b29"
+brotli@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/brotli/-/brotli-1.3.3.tgz#7365d8cc00f12cf765d2b2c898716bcf4b604d48"
+  integrity sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==
   dependencies:
     base64-js "^1.1.2"
 


### PR DESCRIPTION
Quick dependency fix. 

If there is an obvious reason I'm missing to use `github:foliojs/brotli.js` instead of [the version currently available on `npm`](https://www.npmjs.com/package/brotli) (which stems from the same GitHub repository), it would be great to document it.

Cheers.