### PR TITLE
Set `scriptRW` back to empty string when unable to determine script type

### DIFF
--- a/src/rewrite/html.js
+++ b/src/rewrite/html.js
@@ -304,6 +304,8 @@ class HTMLRewriter
           scriptRw = "json";
         } else if (!scriptType || (scriptType.indexOf("javascript") >= 0 || scriptType.indexOf("ecmascript") >= 0)) {
           scriptRw = "js";
+        } else {
+          scriptRw = "";
         }
         break;
       }


### PR DESCRIPTION
Considering following case:

```html
<script type="text/javascript">console.log("hello world!")</script>
<script type="text/json" id="myJson">{"json":true}</script>
<script type="text/javascript">console.log(document.getElementById('myJson').textContent)</script>
```

When parsing the first `script` element, `scriptRW` are setted to `script`; when it comes the second, it never set back to empty string.

It was to process unwanted result for any script block which `type` setted and not javascript.