### PR TITLE
Allow passing blob objects to replayweb.page

### DIFF
--- a/src/blockloaders.js
+++ b/src/blockloaders.js
@@ -401,6 +401,7 @@ class BlobCacheLoader
       try {
         const response = await fetch(this.url);
         this.blob = await response.blob();
+        this.size = this.blob.size;
       } catch (e) {
         console.warn(e);
         throw e;

--- a/src/loaders.js
+++ b/src/loaders.js
@@ -534,7 +534,7 @@ class WorkerLoader extends CollectionLoader
 
       let tryHeadOnly = false;
 
-      if (config.sourceName.endsWith(".wacz") || config.sourceName.endsWith(".zip")) {
+      if (config.sourceName.endsWith(".wacz") || config.sourceName.endsWith(".zip") || config.sourceUrl.startsWith("blob")) {
         // do HEAD request only
         tryHeadOnly = true;
       }
@@ -570,7 +570,7 @@ Make sure this is a valid URL and you have access to this file.`);
 
       const contentLength = sourceLoader.length;
 
-      if (config.sourceName.endsWith(".wacz") || config.sourceName.endsWith(".zip")) {
+      if (config.sourceName.endsWith(".wacz") || config.sourceName.endsWith(".zip") || config.sourceUrl.startsWith("blob")) {
         loader = new SingleWACZLoader(sourceLoader, config, name);
 
         if (config.onDemand) {


### PR DESCRIPTION
- blockloaders.js requires length set during init
- loader.js block unknown file names. Work around to assume blobs are wacz
- possible better solution is to check mime type of blob