### PR TITLE
wacz loading: treat missing profiles as default single-wacz

### DIFF
--- a/src/wacz/waczimporter.js
+++ b/src/wacz/waczimporter.js
@@ -100,6 +100,8 @@ export class WACZImporter
     switch (root.profile) {
     case "data-package":
     case "wacz-package":
+    case undefined:
+    case null:
       return await this.loadLeafWACZPackage(root);
 
     case "multi-wacz-package":


### PR DESCRIPTION
More tolerant for WACZ files that are missing the profile..