### PR TITLE
fix: show attachments inline based on request.destination

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -186,7 +186,8 @@ class Collection {
       response.setRange(range);
     }
 
-    return response.makeResponse(this.coHeaders);
+    const deleteDisposition = (request.destination === "iframe" || request.destination === "document");
+    return response.makeResponse(this.coHeaders, deleteDisposition);
   }
 
   getCanonRedirect(query) {

--- a/src/response.js
+++ b/src/response.js
@@ -209,7 +209,7 @@ class ArchiveResponse
     return true;
   }
 
-  makeResponse(coHeaders = false) {
+  makeResponse(coHeaders = false, overwriteDisposition = false) {
     let body = null;
     if (!isNullBodyStatus(this.status)) {
       body = this.buffer || !this.reader ? this.buffer : this.reader.getReadableStream();
@@ -222,6 +222,9 @@ class ArchiveResponse
     if (coHeaders) {
       response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
       response.headers.set("Cross-Origin-Embedder-Policy", "require-corp");
+    }
+    if (overwriteDisposition) {
+      response.headers.set("content-disposition", "inline");
     }
     return response;
   }


### PR DESCRIPTION
Resolves #133 

I'm not sure how wise it is to always override this based on `request.destination` (rather than as an ExtraConfig option) but this works! 

Screenshot:
![image](https://github.com/webrecorder/wabac.js/assets/22575913/a090d0e0-2100-441f-af39-6ba05e5d8b52)
