### PR TITLE
fix document.close() inject to only be used for JS scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.16.8",
+  "version": "2.16.9",
   "main": "index.js",
   "type": "module",
   "license": "AGPL-3.0-or-later",

--- a/src/rewrite/html.js
+++ b/src/rewrite/html.js
@@ -351,7 +351,7 @@ class HTMLRewriter
           break;
 
         case "script":
-          if (headDone && !isTextEmpty) {
+          if (headDone && !isTextEmpty && (!scriptRw || scriptRw === "js")) {
             rwStream.emitRaw(";document.close();");
           }
           break;

--- a/test/rewriteHTML.js
+++ b/test/rewriteHTML.js
@@ -316,6 +316,12 @@ test("script", rewriteHtml,
    <script>var foo = x;;document.close();</script>
    </body>`);
 
+// SCRIPT tag in body but json
+test("script", rewriteHtml,
+  "<body><script type=\"application/json\">{\"embed top test\": \"http://example.com/a/b/c.html\"}</script></body>",
+  "<body><script type=\"application/json\">{\"embed top test\": \"http://example.com/a/b/c.html\"}</script></body>"
+);
+
 // SCRIPT tag ensure reset after known type
 test("script", rewriteHtml,
   `<script type="application/javascript">document.location.href = "abc";</script>


### PR DESCRIPTION
fixes webrecorder/archiveweb.page#178
bump to 2.16.9