### PR TITLE
API for getting Timestamps from pages

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -53,6 +53,7 @@ class API {
       "index": "coll-index",
       "coll": "c/:coll",
       "urls": "c/:coll/urls",
+      "urlsTs": "c/:coll/ts/",
       "createColl": ["c/create", "POST"],
       "deleteColl": ["c/:coll", "DELETE"],
       "updateAuth": ["c/:coll/updateAuth", "POST"],
@@ -167,6 +168,17 @@ class API {
       urls = urls || [];
 
       return {urls};
+    }
+
+    case "urlsTs": {
+      const coll = await this.collections.getColl(params.coll);
+      if (!coll) {
+        return {error: "collection_not_found"};
+      }
+      const url = params._query.get("url");
+      const timestamps = await coll.store.getTimestampsByURL(url);
+
+      return {"timestamps": timestamps};
     }
 
     case "pages": {

--- a/src/archivedb.js
+++ b/src/archivedb.js
@@ -274,11 +274,10 @@ class ArchiveDB {
 
   async getTimestampsByURL(url) {
     const tx = this.db.transaction("resources");
+    const range = IDBKeyRange.bound([url], [url, MAX_DATE_TS]);
     const results=[]; 
-    for await (const cursor of tx.store.iterate()) {
-      if (cursor.key[0] === url) {
-        results.push(cursor.key[1]);
-      }
+    for await (const cursor of tx.store.iterate(range)) {
+      results.push(cursor.key[1]);
     }
     return results;
   }

--- a/src/archivedb.js
+++ b/src/archivedb.js
@@ -272,6 +272,17 @@ class ArchiveDB {
     return results;
   }
 
+  async getTimestampsByURL(url) {
+    const tx = this.db.transaction("resources");
+    const results=[]; 
+    for await (const cursor of tx.store.iterate()) {
+      if (cursor.key[0] === url) {
+        results.push(cursor.key[1]);
+      }
+    }
+    return results;
+  }
+
   async getPagesWithState(state) {
     return await this.db.getAllFromIndex("pages", "state", state);
   }


### PR DESCRIPTION
Resolves #143 

Returns an array of timestamps that looks like this: 
![image](https://github.com/webrecorder/wabac.js/assets/22575913/984db36a-3632-4080-86b8-cb27ab89b9f9)

Had to pass `url` as a parameter because the `/`s where causing parse failures. 