### PR TITLE
properly index POST requests with empty bodies as POST requests

### DIFF
--- a/src/cdxloader.js
+++ b/src/cdxloader.js
@@ -122,8 +122,8 @@ class CDXFromWARCLoader extends WARCLoader
     }
 
     // url with post query appended
-    if (cdx.requestBody) {
-      entry.url = appendRequestQuery(cdx.url, cdx.requestBody, cdx.method);
+    if (cdx.method && cdx.method !== "GET") {
+      entry.url = appendRequestQuery(cdx.url, cdx.requestBody || "", cdx.method);
     }
 
     this.addResource(entry);

--- a/src/warcloader.js
+++ b/src/warcloader.js
@@ -330,10 +330,10 @@ class WARCLoader extends BaseParser {
       entry.source = this.sourceExtra;
     }
 
-    if (method !== "GET" && requestUrl && requestBody !== null) {
+    if (method !== "GET" && requestUrl) {
       entry.requestUrl = requestUrl;
       entry.method = method;
-      entry.requestBody = requestBody;
+      entry.requestBody = requestBody || "";
     }
 
     return entry;


### PR DESCRIPTION
- in WARC loader, properly load non-GET method even if body is empty.
- in CDX indexer, ensure empty non-GET method goes through proper canonicalization even if body is empty.