### PR TITLE
Improved 'not found' message based on resource type

### DIFF
--- a/src/notfound.js
+++ b/src/notfound.js
@@ -1,0 +1,110 @@
+import { getStatusText } from "./utils.js";
+
+export function notFoundByTypeResponse(request, requestURL, requestTS, liveRedirectOnNotFound = false, status = 404) {
+  let content;
+  let contentType;
+
+  switch (request.destination) {
+  case "json":
+  case "":
+    content = getJSONNotFound(requestURL, requestTS);
+    contentType = "application/json; charset=utf-8";
+    break;
+
+  case "script":
+    content = getScriptCSSNotFound("Script", requestURL, requestTS);
+    contentType = "text/javascript; charset=utf-8";
+    break;
+
+  case "style":
+    content = getScriptCSSNotFound("CSS", requestURL, requestTS);
+    contentType = "text/css; charset=utf-8";
+    break;
+
+  case "document":
+  case "embed":
+  case "iframe":
+  case "frame":
+  default:
+    console.log("wb not found", request.destination);
+    content = getHTMLNotFound(request, requestURL, requestTS, liveRedirectOnNotFound);
+    contentType = "text/html; charset=utf-8";
+  }
+
+  const buff = new TextEncoder().encode(content);
+
+  const initOpt = {
+    "status": status,
+    "statusText": getStatusText(status),
+    "headers": { "Content-Type": contentType, "Content-Length": buff.length }
+  };
+
+  return new Response(buff, initOpt);
+}
+
+
+function getHTMLNotFound(request, requestURL, requestTS, liveRedirectOnNotFound) {
+  return `
+  <!doctype html>
+  <html>
+  <head>
+  <script>
+  window.requestURL = "${requestURL}";
+  </script>
+  </head>
+  <body style="font-family: sans-serif">
+  <h2>Archived Page Not Found</h2>
+  <p>Sorry, this page was not found in this archive:</p>
+  <p><code id="url" style="word-break: break-all; font-size: larger"></code></p>
+  ${liveRedirectOnNotFound && request.mode === "navigate" ? `
+  <p>Redirecting to live page now... (If this URL is a file download, the download should have started).</p>
+  <script>
+  window.top.location.href = window.requestURL;
+  </script>
+  ` : `
+  `}
+  <p id="goback" style="display: none"><a href="#" onclick="window.history.back()">Go Back</a> to the previous page.</a></p>
+  
+  <p>
+  <a id="livelink" target="_blank" href="">Load the live page</a> in a new tab (or download the file, if this URL points to a file).
+  </p>
+
+  <script>
+  document.querySelector("#url").innerText = window.requestURL;
+  document.querySelector("#livelink").href = window.requestURL;
+  let isTop = true;
+  try {
+    if (window.parent._WB_wombat_location) {
+      isTop = false;
+    }
+  } catch (e) {
+
+  }
+  if (isTop) {
+    document.querySelector("#goback").style.display = "";
+
+    window.parent.postMessage({
+      wb_type: "archive-not-found",
+      url: window.requestURL,
+      ts: "${requestTS}"
+    }, "*");
+  }
+  </script>
+  </body>
+  </html>
+  `;
+}
+
+function getScriptCSSNotFound(type, requestURL, requestTS) {
+  return `\
+/* 
+   ${type} Not Found
+   URL: ${requestURL}
+   TS: ${requestTS}
+*/
+  `;
+}
+
+function getJSONNotFound(URL, TS, error = "not_found") {
+  return JSON.stringify({error, URL, TS});
+}


### PR DESCRIPTION
Previously, an HTML 404 page was returned for all not found errors. This adjusts that to return a potentially more type-appropriate error message, which may improve fidelity (eg. reduce syntax errors where HTML is parsed as JSON) by returning error messages in appropriate type. Thus far, HTML, CSS, JS and JSON error messages are supported.

Also - tweak the about:blank response to make it more compatible, removing `<!doctype html>` which is not part of standard about:blank