### PR TITLE
live proxy improvements error reporting improvements

### DIFF
--- a/src/rewrite/html.ts
+++ b/src/rewrite/html.ts
@@ -249,7 +249,7 @@ class HTMLRewriter {
         // convert object tag to iframe or img
         if (type === "application/pdf") {
           attr.name = "src";
-          attr.value = this.rewriteUrl(rewriter, attr.value);
+          attr.value = this.rewriteUrl(rewriter, attr.value, false, "if_");
           tag.tagName = "iframe";
         } else if (type === "image/svg+xml") {
           attr.name = "src";
@@ -260,7 +260,7 @@ class HTMLRewriter {
             const value = attr.value.replace(rule.match, rule.replace);
             if (value !== attr.value) {
               attr.name = "src";
-              attr.value = this.rewriteUrl(rewriter, value);
+              attr.value = this.rewriteUrl(rewriter, value, false, "if_");
               tag.tagName = "iframe";
               break;
             }
@@ -277,6 +277,12 @@ class HTMLRewriter {
         ) {
           attr.value = REPLAY_TOP_FRAME_NAME;
         }
+      } else if (
+        name === "src" &&
+        (tagName === "iframe" || tagName === "frame")
+      ) {
+        const mod = attrRules[name];
+        attr.value = this.rewriteUrl(rewriter, attr.value, false, mod);
       } else if (name === "href" || name === "src") {
         attr.value = this.rewriteUrl(rewriter, attr.value);
       } else {
@@ -506,7 +512,7 @@ class HTMLRewriter {
       text = decoder.decode(encodeLatin1(text));
     }
     const res = rewriter.rewriteUrl(text, forceAbs);
-    return mod ? res.replace("mp_/", mod + "/") : res;
+    return mod && mod !== defmod ? res.replace(defmod + "/", mod + "/") : res;
   }
 
   rewriteHTMLText(text: string) {

--- a/test/rewriteHTML.ts
+++ b/test/rewriteHTML.ts
@@ -569,10 +569,17 @@ test(
 );
 
 test(
+  "iframe rw",
+  rewriteHtml,
+  '<iframe src="https://example.com/iframe.html"></iframe>',
+  '<iframe src="http://localhost:8080/prefix/20201226101010if_/https://example.com/iframe.html"></iframe>',
+);
+
+test(
   "object pdf",
   rewriteHtml,
   '<object type="application/pdf" data="https://example.com/some/file.pdf">',
-  '<iframe type="application/pdf" src="http://localhost:8080/prefix/20201226101010mp_/https://example.com/some/file.pdf">',
+  '<iframe type="application/pdf" src="http://localhost:8080/prefix/20201226101010if_/https://example.com/some/file.pdf">',
 );
 
 test(


### PR DESCRIPTION
- add custom error page for live proxy errors for >400 (except 404) status responses
- error page sends a 'live-proxy-url-error' from page when loaded
- add option to send messages when proxy POST request fail, or when rate limited, if messageOnProxyErrors is set, sending 'rate-limited' and 'post-request-failed' from the service worker

rewrite:
- use if_ / fr_/ modifiers for iframes / frames again to help differentiate frames for live proxy
- add tests for if_ frame rewrite