### PR TITLE
Fixes for 'proxy' mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -389,7 +389,7 @@ export class Collection {
       return response;
     }
 
-    const opts = { pageId: query.pageId, noRedirect: query.isProxyOrigin};
+    const opts = { pageId: query.pageId, noRedirect: query.isProxyOrigin };
 
     response = await this.store.getResource(query, this.prefix, event, opts);
 

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -389,7 +389,7 @@ export class Collection {
       return response;
     }
 
-    const opts = { pageId: query.pageId };
+    const opts = { pageId: query.pageId, noRedirect: query.isProxyOrigin};
 
     response = await this.store.getResource(query, this.prefix, event, opts);
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -11,6 +11,8 @@ export class ArchiveRequest {
   hash = "";
   cookie = "";
 
+  isProxyOrigin = false;
+
   request: Request;
   method: string;
   mode: string;
@@ -66,6 +68,7 @@ export class ArchiveRequest {
       if (url.origin === localOrigin) {
         this.url = proxyOrigin + url.pathname + (url.search ? url.search : "");
       }
+      this.isProxyOrigin = true;
     }
 
     const hashIndex = this.url.indexOf("#");

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1049,7 +1049,7 @@ export class MultiWACZ
     event: FetchEvent,
     // [TODO]
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    { pageId }: Record<string, any> = {},
+    { pageId, noRedirect }: Record<string, any> = {},
   ): Promise<ArchiveResponse | Response | null> {
     await this.initing;
 
@@ -1097,6 +1097,9 @@ export class MultiWACZ
         loadFirst: true,
       });
       if (resp) {
+        if (noRedirect) {
+          return resp;
+        }
         foundMap.set((resp as ArchiveResponse).date, { name, hash: file.hash });
       }
     }


### PR DESCRIPTION
- Don't redirect in proxy origin mode when replaying WACZ
- Fixes 'proxy origin' (non-rewriting mode) replay, as used in: https://github.com/ikreymer/proxy-wabac
- bump to 2.20.1