### PR TITLE
Fix for FB video replay

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "path-parser": "^6.1.0",
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
-    "warcio": "^2.4.1"
+    "warcio": "^2.4.2"
   },
   "devDependencies": {
     "@swc-node/register": "^1.10.9",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "path-parser": "^6.1.0",
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
-    "warcio": "^2.4.0"
+    "warcio": "^2.4.1"
   },
   "devDependencies": {
     "@swc-node/register": "^1.10.9",

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1,5 +1,4 @@
 import { Rewriter } from "./rewrite";
-import { removeRangeAsQuery } from "./rewrite/dsruleset";
 
 import {
   getTS,
@@ -163,10 +162,6 @@ export class Collection {
           this.adblockUrl,
         );
       } else {
-        const filterUrl = removeRangeAsQuery(request.url);
-        if (filterUrl) {
-          request.url = filterUrl;
-        }
         response = await this.getReplayResponse(request, event);
         if (
           response &&
@@ -260,7 +255,7 @@ export class Collection {
 
       const rewriter = new Rewriter(rewriteOpts);
 
-      response = await rewriter.rewrite(response, request, requestURL);
+      response = await rewriter.rewrite(response, request);
 
       if (mod !== "id_") {
         response.headers.append("Content-Security-Policy", this.csp);

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -163,6 +163,7 @@ export class Collection {
         );
       } else {
         response = await this.getReplayResponse(request, event);
+        requestURL = request.url;
         if (
           response &&
           response instanceof ArchiveResponse &&

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1,4 +1,5 @@
-import { Rewriter } from "./rewrite/index";
+import { Rewriter } from "./rewrite";
+import { removeRangeAsQuery } from "./rewrite/dsruleset";
 
 import {
   getTS,
@@ -162,8 +163,11 @@ export class Collection {
           this.adblockUrl,
         );
       } else {
+        const filterUrl = removeRangeAsQuery(request.url);
+        if (filterUrl) {
+          request.url = filterUrl;
+        }
         response = await this.getReplayResponse(request, event);
-        requestURL = request.url;
         if (
           response &&
           response instanceof ArchiveResponse &&
@@ -256,7 +260,7 @@ export class Collection {
 
       const rewriter = new Rewriter(rewriteOpts);
 
-      response = await rewriter.rewrite(response, request);
+      response = await rewriter.rewrite(response, request, requestURL);
 
       if (mod !== "id_") {
         response.headers.append("Content-Security-Policy", this.csp);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export {
   Rewriter,
 } from "./rewrite";
 
+export { removeRangeAsQuery, hasRangeAsQuery } from "./rewrite/dsruleset";
+
 export { ArchiveRequest } from "./request";
 
 export { ArchiveResponse } from "./response";

--- a/src/response.ts
+++ b/src/response.ts
@@ -137,8 +137,6 @@ class ArchiveResponse {
 
   clonedResponse: Response | null = null;
 
-  rewritten = false;
-
   constructor({
     payload,
     status,

--- a/src/rewrite/dsruleset.ts
+++ b/src/rewrite/dsruleset.ts
@@ -175,7 +175,6 @@ export function ruleRewriteFBDash(text: string, opts: Record<string, any>) {
   const rwtext: string = JSON.parse('"' + text.slice(start, end) + '"');
 
   let rw = rewriteDASH(rwtext, opts);
-  console.log("FB DASH", rw);
 
   rw = JSON.stringify(rw).replaceAll("<", "\\u003C").slice(1, -1);
 

--- a/src/rewrite/dsruleset.ts
+++ b/src/rewrite/dsruleset.ts
@@ -140,6 +140,9 @@ const RANGE_RULES = [
 ];
 
 export function hasRangeAsQuery(url: string) {
+  if (!url) {
+    return null;
+  }
   for (const rule of RANGE_RULES) {
     const { contains, start, end } = rule;
     if (url.match(contains)) {

--- a/src/rewrite/dsruleset.ts
+++ b/src/rewrite/dsruleset.ts
@@ -50,14 +50,8 @@ export const DEFAULT_RULES: Rules[] = [
   {
     contains: ["facebook.com/", "fbsbx.com/"],
     rxRules: [
-      //[/"dash_prefetch_experimental.*"playlist".*?(?=["][,]["]dash)/, ruleRewriteFBDash],
-      //[/\\u003C\?xml.*\\u003C\/MPD>/, ruleRewriteFBDash],
-      //[/<\?xml(.|\n)*<\/MPD>/, ruleRewriteFBDash],
       [/"dash_manifests.*?,"failure_reason":null}]/, ruleRewriteFBDash],
-      //[/"dash_manifests.*?,"failure_reason":null}]/, ruleReplace('"dash_manifests":[{"manifest_xml":null, "failure_reason":{"type":"NotEligibleForDash"}}]')],
-      //[/"dash_manifests.*?,"failure_reason":null}]/, ruleReplace('"dash_manifests":[{"manifest_xml":null, "failure_reason":{"type":"NotEligibleForDash"}}]')],
-      //[/"dash_manifest_urls.*?,"failure_reason":null}]/, ruleReplace('"dash_manifest_urls":[{"manifest_url":null, "failure_reason":{"type":"NotEligibleForDash"}}]')],
-
+      //[/"dash_/, ruleReplace('"__nodash__')],
       //[/_dash"/, ruleReplace('__nodash__"')],
       //[/_dash_/, ruleReplace("__nodash__")],
       [/"playlist/, ruleReplace('"__playlist__')],

--- a/src/rewrite/dsruleset.ts
+++ b/src/rewrite/dsruleset.ts
@@ -1,3 +1,4 @@
+import { rewriteDASH } from "./rewriteVideo";
 import { type RxRewriter, type Rule } from "./rxrewriter";
 
 //import unescapeJs from "unescape-js";
@@ -50,9 +51,15 @@ export const DEFAULT_RULES: Rules[] = [
     contains: ["facebook.com/", "fbsbx.com/"],
     rxRules: [
       //[/"dash_prefetch_experimental.*"playlist".*?(?=["][,]["]dash)/, ruleRewriteFBDash],
-      [/"dash_/, ruleReplace('"__nodash__')],
-      [/_dash"/, ruleReplace('__nodash__"')],
-      [/_dash_/, ruleReplace("__nodash__")],
+      //[/\\u003C\?xml.*\\u003C\/MPD>/, ruleRewriteFBDash],
+      //[/<\?xml(.|\n)*<\/MPD>/, ruleRewriteFBDash],
+      [/"dash_manifests.*?,"failure_reason":null}]/, ruleRewriteFBDash],
+      //[/"dash_manifests.*?,"failure_reason":null}]/, ruleReplace('"dash_manifests":[{"manifest_xml":null, "failure_reason":{"type":"NotEligibleForDash"}}]')],
+      //[/"dash_manifests.*?,"failure_reason":null}]/, ruleReplace('"dash_manifests":[{"manifest_xml":null, "failure_reason":{"type":"NotEligibleForDash"}}]')],
+      //[/"dash_manifest_urls.*?,"failure_reason":null}]/, ruleReplace('"dash_manifest_urls":[{"manifest_url":null, "failure_reason":{"type":"NotEligibleForDash"}}]')],
+
+      //[/_dash"/, ruleReplace('__nodash__"')],
+      //[/_dash_/, ruleReplace("__nodash__")],
       [/"playlist/, ruleReplace('"__playlist__')],
       [
         /"debugNoBatching\s?":(?:false|0)/,
@@ -123,6 +130,60 @@ export const HTML_ONLY_RULES: Rules[] = [
   },
   ...DEFAULT_RULES,
 ];
+
+const RANGE_RULES = [
+  {
+    contains: /video.*fbcdn.net/,
+    start: "bytestart",
+    end: "byteend",
+  },
+];
+
+export function hasRangeAsQuery(url: string) {
+  for (const rule of RANGE_RULES) {
+    const { contains, start, end } = rule;
+    if (url.match(contains)) {
+      return { start, end };
+    }
+  }
+
+  return null;
+}
+
+export function removeRangeAsQuery(url: string) {
+  const result = hasRangeAsQuery(url);
+  if (!result) {
+    return null;
+  }
+  try {
+    const parsedUrl = new URL(url);
+    if (
+      !parsedUrl.searchParams.has(result.start) ||
+      !parsedUrl.searchParams.has(result.end)
+    ) {
+      return null;
+    }
+    parsedUrl.searchParams.delete(result.start);
+    parsedUrl.searchParams.delete(result.end);
+    return parsedUrl.href;
+  } catch (_e) {
+    return null;
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function ruleRewriteFBDash(text: string, opts: Record<string, any>) {
+  const start = text.indexOf("\\u003C?xml");
+  const end = text.indexOf("\\u003C\\/MPD>", start) + "\\u003C\\/MPD>".length;
+  const rwtext: string = JSON.parse('"' + text.slice(start, end) + '"');
+
+  let rw = rewriteDASH(rwtext, opts);
+  console.log("FB DASH", rw);
+
+  rw = JSON.stringify(rw).replaceAll("<", "\\u003C").slice(1, -1);
+
+  return text.slice(0, start) + rw + text.slice(end);
+}
 
 // ===========================================================================
 function ruleReplace(str: string) {

--- a/src/rewrite/index.ts
+++ b/src/rewrite/index.ts
@@ -6,7 +6,11 @@ import { decodeResponse } from "./decoder";
 
 import { rewriteDASH, rewriteHLS } from "./rewriteVideo";
 
-import { DomainSpecificRuleSet, HTML_ONLY_RULES } from "./dsruleset";
+import {
+  DomainSpecificRuleSet,
+  hasRangeAsQuery,
+  HTML_ONLY_RULES,
+} from "./dsruleset";
 
 import { RxRewriter } from "./rxrewriter";
 import { JSRewriter } from "./jsrewriter";
@@ -216,6 +220,7 @@ export class Rewriter {
   async rewrite(
     response: ArchiveResponse,
     request: ArchiveRequest,
+    requestURL: string,
   ): Promise<ArchiveResponse> {
     const rewriteMode = this.contentRewrite
       ? this.getRewriteMode(request, response, this.baseUrl)
@@ -322,6 +327,26 @@ export class Rewriter {
         this.isCharsetUTF8 = true;
       }
       response.setText(text, this.isCharsetUTF8);
+    } else {
+      // check range-as-query
+      const result = hasRangeAsQuery(requestURL);
+      if (result) {
+        const url = new URL(requestURL);
+        const start = parseInt(url.searchParams.get(result.start) || "");
+        const end = parseInt(url.searchParams.get(result.end) || "");
+        if (!isNaN(start) && !isNaN(end)) {
+          const existingLen = Number(response.headers.get("Content-Length"));
+          const newLen = end - start + 1;
+          if (
+            existingLen !== newLen &&
+            (isNaN(existingLen) || existingLen > newLen) &&
+            response.setRawRange(start, end)
+          ) {
+            console.log("setting range", start, end, newLen);
+            response.headers.set("Content-Length", String(newLen));
+          }
+        }
+      }
     }
 
     return response;

--- a/src/rewrite/index.ts
+++ b/src/rewrite/index.ts
@@ -220,7 +220,6 @@ export class Rewriter {
   async rewrite(
     response: ArchiveResponse,
     request: ArchiveRequest,
-    requestURL: string,
   ): Promise<ArchiveResponse> {
     const rewriteMode = this.contentRewrite
       ? this.getRewriteMode(request, response, this.baseUrl)
@@ -329,9 +328,9 @@ export class Rewriter {
       response.setText(text, this.isCharsetUTF8);
     } else {
       // check range-as-query
-      const result = hasRangeAsQuery(requestURL);
+      const result = hasRangeAsQuery(request.url);
       if (result) {
-        const url = new URL(requestURL);
+        const url = new URL(request.url);
         const start = parseInt(url.searchParams.get(result.start) || "");
         const end = parseInt(url.searchParams.get(result.end) || "");
         if (!isNaN(start) && !isNaN(end)) {

--- a/test/rewriteVideo.ts
+++ b/test/rewriteVideo.ts
@@ -208,6 +208,7 @@ const test4 = ytplayer.config.args.dash = "0"; ytplayer.config.args.dashmpd = ""
   t.is(result, expected, result);
 });
 
+/*
 test("FB rewrite JS", async (t) => {
   const content = `\
 <script>
@@ -228,6 +229,7 @@ const test1 = {"__nodash__url": "foo", {"some__nodash__": "a", "data__nodash__fo
   });
   t.is(result, expected);
 });
+*/
 
 test("Twitter rewrite json", async (t) => {
   const content = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3764,10 +3764,10 @@ warcio@^2.4.0:
     uuid-random "^1.3.2"
     yargs "^17.7.2"
 
-warcio@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.1.tgz#6b4c68ba926f415f506ed9c28eef7fa5b7bcb2d8"
-  integrity sha512-Tmlv/O7tl4bcJzY38REFNoeRXTPx9BoSSUUpGcZpUdogY3A0UX6yMWybVc4UN6OCxPMeJyt+K1mZ0I/0tKiFBQ==
+warcio@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.2.tgz#782d8dcb0769f271b0ae96521fb4969e2570e9b3"
+  integrity sha512-QYbZ3EGYtnAIrzL7Bajo7ak87pipilpkIfaFIzFQWUX4wuXNuKqnfQy/EAoi2tEIl3VJgsWcL+wjjk4+15MKbQ==
   dependencies:
     "@types/pako" "^1.0.7"
     "@types/stream-buffers" "^3.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3764,6 +3764,20 @@ warcio@^2.4.0:
     uuid-random "^1.3.2"
     yargs "^17.7.2"
 
+warcio@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/warcio/-/warcio-2.4.1.tgz#6b4c68ba926f415f506ed9c28eef7fa5b7bcb2d8"
+  integrity sha512-Tmlv/O7tl4bcJzY38REFNoeRXTPx9BoSSUUpGcZpUdogY3A0UX6yMWybVc4UN6OCxPMeJyt+K1mZ0I/0tKiFBQ==
+  dependencies:
+    "@types/pako" "^1.0.7"
+    "@types/stream-buffers" "^3.0.7"
+    base32-encode "^2.0.0"
+    hash-wasm "^4.9.0"
+    pako "^1.0.11"
+    tempy "^3.1.0"
+    uuid-random "^1.3.2"
+    yargs "^17.7.2"
+
 watchpack@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"


### PR DESCRIPTION
- New fuzzy matching rules for FB, matching and rewriting embedded DASH (again)
- New ruleset: range-as-query args configured per domain, allows lookup of range requests set via query args
- APIs: add hasRangeAsQuery() and removeRangeAsQuery() to detect if URL has range embedded in the query args
- Part of fix for webrecorder/archiveweb.page#272