### PR TITLE
rewrite: fix new FB dash parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.20.4",
+  "version": "2.20.5",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/rewrite/dsruleset.ts
+++ b/src/rewrite/dsruleset.ts
@@ -171,7 +171,12 @@ export function removeRangeAsQuery(url: string) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function ruleRewriteFBDash(text: string, opts: Record<string, any>) {
   const start = text.indexOf("\\u003C?xml");
-  const end = text.indexOf("\\u003C\\/MPD>", start) + "\\u003C\\/MPD>".length;
+  let end = text.indexOf("/MPD>", start);
+  if (end < 0) {
+    return text;
+  }
+  end += "/MPD>".length;
+
   const rwtext: string = JSON.parse('"' + text.slice(start, end) + '"');
 
   let rw = rewriteDASH(rwtext, opts);

--- a/src/rewrite/dsruleset.ts
+++ b/src/rewrite/dsruleset.ts
@@ -170,12 +170,15 @@ export function removeRangeAsQuery(url: string) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function ruleRewriteFBDash(text: string, opts: Record<string, any>) {
-  const start = text.indexOf("\\u003C?xml");
-  let end = text.indexOf("/MPD>", start);
-  if (end < 0) {
+  const START_TAG = "\\u003C?xml";
+  const END_TAG = "/MPD>";
+
+  const start = text.indexOf(START_TAG);
+  const end = text.indexOf(END_TAG, start) + END_TAG.length;
+  // if not found, will be END_TAG.length - 1
+  if (end < END_TAG.length) {
     return text;
   }
-  end += "/MPD>".length;
 
   const rwtext: string = JSON.parse('"' + text.slice(start, end) + '"');
 


### PR DESCRIPTION
Follow-up to #212, additional fixes to embedded dash manifests:
- better search for end tag
- don't attempt rewrite if end tag not found
- bump to 2.20.5