### PR TITLE
Support for dynamic page loading + multi WACZ loading optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.20.8",
+  "version": "2.20.9.1",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.21.0-beta.0",
+  "version": "2.21.0",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.20.9.1",
+  "version": "2.21.0-beta.0",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@peculiar/asn1-schema": "^2.3.3",
     "@peculiar/x509": "^1.9.2",
     "@types/js-levenshtein": "^1.1.3",
-    "@webrecorder/wombat": "^3.8.7",
+    "@webrecorder/wombat": "^3.8.8",
     "acorn": "^8.10.0",
     "auto-js-ipfs": "^2.1.1",
     "base64-js": "^1.5.1",

--- a/src/api.ts
+++ b/src/api.ts
@@ -297,6 +297,16 @@ class API {
         if (!coll) {
           return { error: "collection_not_found" };
         }
+        if (coll.store instanceof MultiWACZ) {
+          // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
+          const q = params._query.get("q");
+          // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
+          const limit = Number(params._query.get("limit")) || 25;
+          if (q) {
+            const pages = await coll.store.queryPages(q, limit);
+            return { pages };
+          }
+        }
         const pages = await coll.store.getAllPages();
         return { pages };
       }

--- a/src/api.ts
+++ b/src/api.ts
@@ -306,8 +306,8 @@ class API {
           const pageSize = Number(params._query.get("pageSize")) || 25;
           if (q) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            const pages = await coll.store.queryPages(q, page, pageSize);
-            return { pages };
+            const { pages, total } = await coll.store.queryPages(q, page, pageSize);
+            return { pages, total };
           }
         }
         const pages = await coll.store.getAllPages();

--- a/src/api.ts
+++ b/src/api.ts
@@ -303,6 +303,7 @@ class API {
           // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
           const limit = Number(params._query.get("limit")) || 25;
           if (q) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             const pages = await coll.store.queryPages(q, limit);
             return { pages };
           }

--- a/src/api.ts
+++ b/src/api.ts
@@ -305,7 +305,7 @@ class API {
           const page = Number(params._query.get("page")) || 1;
           // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
           const pageSize = Number(params._query.get("pageSize")) || 25;
-          if (search) {
+          if (search || page > 1) {
             const { pages, total } = await coll.store.queryPages(
               // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
               search,

--- a/src/api.ts
+++ b/src/api.ts
@@ -128,7 +128,7 @@ class API {
             data.lists = await coll.store.db.getAll("pageLists");
             data.curatedPages = await coll.store.db.getAll("curatedPages");
             if (coll.store instanceof MultiWACZ) {
-              data.hasPagesQuery = !!coll.store.pagesQuery;
+              data.canQueryPages = !!coll.store.pagesQueryUrl;
             }
           } else {
             data.pages = [];
@@ -299,14 +299,18 @@ class API {
         }
         if (coll.store instanceof MultiWACZ) {
           // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
-          const q = params._query.get("q");
+          const search = params._query.get("search");
           // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
           const page = Number(params._query.get("page")) || 1;
           // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
           const pageSize = Number(params._query.get("pageSize")) || 25;
-          if (q) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            const { pages, total } = await coll.store.queryPages(q, page, pageSize);
+          if (search) {
+             
+            const { pages, total } = await coll.store.queryPages(
+              search,
+              page,
+              pageSize,
+            );
             return { pages, total };
           }
         }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import { Path } from "path-parser";
 import { getCollData } from "./utils";
 import { type SWCollections } from "./swmain";
+import { MultiWACZ } from "./wacz/multiwacz";
 
 // [TODO]
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -126,6 +127,9 @@ class API {
             data.pages = await coll.store.getAllPages();
             data.lists = await coll.store.db.getAll("pageLists");
             data.curatedPages = await coll.store.db.getAll("curatedPages");
+            if (coll.store instanceof MultiWACZ) {
+              data.hasPagesQuery = !!coll.store.pagesQuery;
+            }
           } else {
             data.pages = [];
             data.lists = [];

--- a/src/api.ts
+++ b/src/api.ts
@@ -301,10 +301,12 @@ class API {
           // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
           const q = params._query.get("q");
           // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
-          const limit = Number(params._query.get("limit")) || 25;
+          const page = Number(params._query.get("page")) || 1;
+          // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
+          const pageSize = Number(params._query.get("pageSize")) || 25;
           if (q) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            const pages = await coll.store.queryPages(q, limit);
+            const pages = await coll.store.queryPages(q, page, pageSize);
             return { pages };
           }
         }

--- a/src/api.ts
+++ b/src/api.ts
@@ -305,8 +305,8 @@ class API {
           // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
           const pageSize = Number(params._query.get("pageSize")) || 25;
           if (search) {
-             
             const { pages, total } = await coll.store.queryPages(
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
               search,
               page,
               pageSize,

--- a/src/api.ts
+++ b/src/api.ts
@@ -297,6 +297,7 @@ class API {
         if (!coll) {
           return { error: "collection_not_found" };
         }
+        let total = undefined;
         if (coll.store instanceof MultiWACZ) {
           // @ts-expect-error [TODO] - TS4111 - Property '_query' comes from an index signature, so it must be accessed with ['_query'].
           const search = params._query.get("search");
@@ -312,10 +313,12 @@ class API {
               pageSize,
             );
             return { pages, total };
+          } else {
+            total = coll.store.totalPages;
           }
         }
         const pages = await coll.store.getAllPages();
-        return { pages };
+        return { pages, total };
       }
 
       case "textIndex": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,13 @@ export type PageEntry = {
 
   timestamp?: string;
 
+  mime?: string;
+  depth?: number;
+  status?: number;
+  favIconUrl?: string;
+  wacz?: string;
+  waczhash?: string;
+
   pos?: number;
   // [TODO]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export type PageEntry = {
   favIconUrl?: string;
   wacz?: string;
   waczhash?: string;
+  isSeed?: boolean;
 
   pos?: number;
   // [TODO]

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1046,8 +1046,8 @@ export class MultiWACZ
         waczhash,
       });
       if (isSeed) {
-         
         const set: Set<string> =
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           this.seedPageWACZs.get(crawl_id) || new Set<string>();
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         set.add(filename);

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -100,6 +100,8 @@ export class MultiWACZ
 
   pagesQueryUrl = "";
 
+  totalPages?: number = undefined;
+
   preloadResources: string[] = [];
   seedPageWACZs: Map<string, Set<string>> = new Map<string, Set<string>>();
 
@@ -959,7 +961,7 @@ export class MultiWACZ
   async loadWACZFiles(
     // [TODO]
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    json: { resources: any; seedPages: any; preloadResources: any },
+    json: { resources: any; initialPages: any; preloadResources: any, totalPages: number },
     parent: WACZLoadSource = this,
   ) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1009,14 +1011,18 @@ export class MultiWACZ
       }
     }
 
-    if (json.seedPages) {
+    if (json.initialPages) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      await this.addSeedPages(json.seedPages);
+      await this.addInitialPages(json.initialPages);
+    }
+
+    if (!isNaN(json.totalPages)) {
+      this.totalPages = json.totalPages;
     }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async addSeedPages(pagesImport: Record<string, any>[]) {
+  async addInitialPages(pagesImport: Record<string, any>[]) {
     const pages: PageEntry[] = [];
     for (const {
       id,

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1263,7 +1263,7 @@ export class MultiWACZ
     page = 1,
     pageSize = 25,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): Promise<Record<string, any>[]> {
+  ): Promise<{pages: Record<string, any>[], total: number}> {
     const params = new URLSearchParams();
     params.set("search", search);
     params.set("page", page + "");
@@ -1272,14 +1272,17 @@ export class MultiWACZ
       headers: this.sourceLoader?.headers,
     });
     if (res.status !== 200) {
-      return [];
+      return {pages: [], total: 0};
     }
     const json = await res.json();
     if (!json) {
-      return [];
+      return {pages: [], total: 0};
     }
+
+    const total = json.total;
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const pages = json.items.map((x: any) => {
+    const pages : Record<string, any>[] = json.items.map((x: any) => {
       x.wacz = x.filename;
       const file = this.waczfiles[x.filename];
       if (file) {
@@ -1293,8 +1296,7 @@ export class MultiWACZ
       return x;
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return pages;
+    return {pages, total};
   }
 
   async getWACZFilesToTry(request: ArchiveRequest, waczname: string | null) {

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -917,7 +917,7 @@ export class MultiWACZ
     path,
     parent,
     loader = null,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }: WACZFileInitOptions & { name: string }): Promise<Record<string, any>> {
     const waczname = name || path || "";
 
@@ -1240,8 +1240,12 @@ export class MultiWACZ
     }
   }
 
+   
+  async queryPages(
+    urlPrefix: string,
+    limit = 25,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async queryPages(urlPrefix: string, limit = 25) : Promise<Record<string, any>[]> {
+  ): Promise<Record<string, any>[]> {
     const params = new URLSearchParams();
     params.set("urlPrefix", urlPrefix);
     params.set("pageSize", limit + "");
@@ -1262,7 +1266,7 @@ export class MultiWACZ
       if (file) {
         x.waczhash = file.hash;
       }
-      if (typeof(x.ts) === "string") {
+      if (typeof x.ts === "string") {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         x.ts = new Date(x.ts).getTime();
       }

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1275,13 +1275,15 @@ export class MultiWACZ
   }
 
   async queryPages(
-    search: string,
+    search = "",
     page = 1,
     pageSize = 25,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<{ pages: Record<string, any>[]; total: number }> {
     const params = new URLSearchParams();
-    params.set("search", search);
+    if (search) {
+      params.set("search", search);
+    }
     params.set("page", page + "");
     params.set("pageSize", pageSize + "");
     const res = await fetch(this.pagesQueryUrl + "?" + params.toString(), {

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -960,8 +960,16 @@ export class MultiWACZ
 
   async loadWACZFiles(
     // [TODO]
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    json: { resources: any; initialPages: any; preloadResources: any, totalPages: number },
+
+    json: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      resources: any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      initialPages: any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      preloadResources: any;
+      totalPages: number;
+    },
     parent: WACZLoadSource = this,
   ) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1058,7 +1058,7 @@ export class MultiWACZ
         favIconUrl,
         wacz: filename,
         waczhash,
-        isSeed
+        isSeed,
       });
       if (isSeed) {
         const set: Set<string> =

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1240,6 +1240,40 @@ export class MultiWACZ
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async queryPages(urlPrefix: string, limit = 25) : Promise<Record<string, any>[]> {
+    const params = new URLSearchParams();
+    params.set("urlPrefix", urlPrefix);
+    params.set("pageSize", limit + "");
+    const res = await fetch(this.pagesQuery + "?" + params.toString(), {
+      headers: this.sourceLoader?.headers,
+    });
+    if (res.status !== 200) {
+      return [];
+    }
+    const json = await res.json();
+    if (!json) {
+      return [];
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pages = json.items.map((x: any) => {
+      x.wacz = x.filename;
+      const file = this.waczfiles[x.filename];
+      if (file) {
+        x.waczhash = file.hash;
+      }
+      if (typeof(x.ts) === "string") {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        x.ts = new Date(x.ts).getTime();
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return x;
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return pages;
+  }
+
   async getWACZFilesForPagesQuery(requestUrl: string) {
     const params = new URLSearchParams();
     const url = new URL(requestUrl);

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1058,6 +1058,7 @@ export class MultiWACZ
         favIconUrl,
         wacz: filename,
         waczhash,
+        isSeed
       });
       if (isSeed) {
         const set: Set<string> =

--- a/src/wacz/waczfile.ts
+++ b/src/wacz/waczfile.ts
@@ -35,6 +35,7 @@ export type WACZFileInitOptions = {
   path?: string;
   parent?: WACZLoadSource | null;
   fileType?: WACZType;
+  crawlId?: string;
   indexType?: IndexType;
   // [TODO]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -47,13 +48,14 @@ export type WACZFileInitOptions = {
 export type WACZFileOptions = WACZFileInitOptions & {
   waczname: string;
   hash: string;
-};
+}
 
 // ==========================================================================
 export class WACZFile implements WACZLoadSource {
   waczname?: string;
   hash?: string;
   path?: string;
+  crawlId?: string;
   parent: WACZLoadSource | null;
   fileType: WACZType;
   indexType: IndexType;
@@ -74,6 +76,7 @@ export class WACZFile implements WACZLoadSource {
     indexType = INDEX_NOT_LOADED,
     nonSurt = false,
     loader = null,
+    crawlId,
   }: WACZFileInitOptions) {
     this.waczname = waczname;
     this.hash = hash;
@@ -85,6 +88,7 @@ export class WACZFile implements WACZLoadSource {
     this.indexType = indexType;
     this.fileType = fileType;
     this.nonSurt = nonSurt;
+    this.crawlId = crawlId;
   }
 
   markAsMultiWACZ() {
@@ -143,6 +147,7 @@ export class WACZFile implements WACZLoadSource {
       waczname: this.waczname,
       hash: this.hash,
       path: this.path,
+      crawlId: this.crawlId,
       entries: this.entries,
       indexType: this.indexType,
       nonSurt: this.nonSurt,

--- a/src/wacz/waczfile.ts
+++ b/src/wacz/waczfile.ts
@@ -57,7 +57,7 @@ export class WACZFile implements WACZLoadSource {
   parent: WACZLoadSource | null;
   fileType: WACZType;
   indexType: IndexType;
-  // [TODO]
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   entries: Record<string, any> | null;
   nonSurt: boolean;
@@ -149,7 +149,6 @@ export class WACZFile implements WACZLoadSource {
     };
   }
 
-  // [TODO]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async save(db: any, always = false) {
     const zipreader = this.zipreader;

--- a/src/wacz/waczfile.ts
+++ b/src/wacz/waczfile.ts
@@ -48,7 +48,7 @@ export type WACZFileInitOptions = {
 export type WACZFileOptions = WACZFileInitOptions & {
   waczname: string;
   hash: string;
-}
+};
 
 // ==========================================================================
 export class WACZFile implements WACZLoadSource {

--- a/src/wacz/waczimporter.ts
+++ b/src/wacz/waczimporter.ts
@@ -149,7 +149,7 @@ export class WACZImporter {
 
       case "multi-wacz-package":
         // [TODO]
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return await this.loadMultiWACZPackage(root);
 
       default:
@@ -159,9 +159,11 @@ export class WACZImporter {
 
   // [TODO]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async loadMultiWACZPackage(root: Record<string, any>) {
+  async loadMultiWACZPackage(root: any) {
     this.file.markAsMultiWACZ();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     await this.store.loadWACZFiles(root, this.file);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return root;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,10 +896,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.2.tgz#ea584b637ff63c5a477f6f21604b5a205b72c9ec"
   integrity sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==
 
-"@webrecorder/wombat@^3.8.7":
-  version "3.8.7"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.8.7.tgz#51c7465c589e0020be064121127c7c10a38ec21f"
-  integrity sha512-bW5V7cBweTkTazOIN8oZZGwHLevsGNv1luY3t0RYdEZhs5BDpTmUHN33zEbrXDOiPUlY3N3I8+73VA+PuxihoQ==
+"@webrecorder/wombat@^3.8.8":
+  version "3.8.8"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.8.8.tgz#aab4dd8eea6d6cb17bfefb7ee1802e7b45b11ed7"
+  integrity sha512-XkJOZAyHrdXNkAVoISQEh/NHzaBMekQZfWqes/k2vYkW6v9DmZ0wjP7Kf6MHCuajKX8uSH+caB2tv1kJgvnv3Q==
   dependencies:
     warcio "^2.4.0"
 


### PR DESCRIPTION
When dealing with multi-WACZ collection specified via json manifest, loading all WACZ files on init becomes unscalable.
This PR provides an initial optimization to:
- Avoid load all WACZ files on load for multi WACZ, if pagesQueryUrl is provided.
- Support for querying pages for exact match 'url' param via pagesQueryUrl to determine if pages exist, and which WACZ files they're in, and only loading those.
- Support for preloadResources to automatically load a subset of WACZ files (such as those that have no pages, for patches).
- Handling of crawl id in pages and wacz files to build a mapping of seed-page-for-crawl to always load the WACZ that contains seed pages.
- Fallback to load all WACZs if < 3 files total.
- Dynamic search interface via pagesQueryUrl with 'search', 'page', 'pageSize' params.
- bump wombat to 3.8.8
- bump to 2.21.0