### PR TITLE
page optimization fixes: lookup urn:<type>:<url> request for corresponding page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1342,7 +1342,7 @@ export class MultiWACZ
       (request.destination === "document" || request.destination === "iframe")
     ) {
       pageUrl = request.url;
-    // thumbnail or other custom resource for page, lookup corresponding page url
+      // thumbnail or other custom resource for page, lookup corresponding page url
     } else if (this.pagesQueryUrl && request.url.startsWith("urn:")) {
       const inx = request.url.indexOf("http");
       if (inx > 0) {


### PR DESCRIPTION
- also lookup corresponding page for 'urn:<type>:<url>' requests, assume <url> is a page
- pages query: don't add null filenames if page has no filename
- bump to 2.21.1