### PR TITLE
support negative offset range for FetchRangeLoader:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/blockloaders.ts
+++ b/src/blockloaders.ts
@@ -88,6 +88,7 @@ export abstract class BaseLoader {
   canLoadOnDemand = true;
   headers: Record<string, string> | Headers = {};
   length: number | null = null;
+  canDoNegativeRange = false;
 
   constructor(canLoadOnDemand: boolean) {
     this.canLoadOnDemand = canLoadOnDemand;
@@ -108,6 +109,24 @@ export abstract class BaseLoader {
   ): Promise<Uint8Array | ReadableStream<Uint8Array>>;
 
   abstract get isValid(): boolean;
+
+  async getRangeFromEnd(
+    length: number,
+    streaming: boolean,
+    signal?: AbortSignal | null,
+  ): Promise<Uint8Array | ReadableStream<Uint8Array>> {
+    if (!this.canDoNegativeRange) {
+      const totalLength = await this.getLength();
+      return await this.getRange(
+        totalLength - length,
+        length,
+        streaming,
+        signal,
+      );
+    } else {
+      return await this.getRange(0, -length, streaming, signal);
+    }
+  }
 }
 
 // ===========================================================================
@@ -136,6 +155,7 @@ class FetchRangeLoader extends BaseLoader {
     this.headers = headers || {};
     this.length = length;
     this.canLoadOnDemand = canLoadOnDemand;
+    this.canDoNegativeRange = true;
   }
 
   override async doInitialFetch(
@@ -194,14 +214,7 @@ class FetchRangeLoader extends BaseLoader {
     if (this.length === null && response) {
       this.length = Number(response.headers.get("Content-Length"));
       if (!this.length && response.status === 206) {
-        const range = response.headers.get("Content-Range");
-        if (range) {
-          const rangeParts = range.split("/");
-          if (rangeParts.length === 2) {
-            // @ts-expect-error [TODO] - TS2345 - Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
-            this.length = parseInt(rangeParts[1]);
-          }
-        }
+        this.parseLengthFromContentRange(response.headers);
       }
     }
 
@@ -240,9 +253,13 @@ class FetchRangeLoader extends BaseLoader {
     length: number,
     streaming = false,
     signal: AbortSignal | null = null,
-  ) {
+  ): Promise<Uint8Array | ReadableStream<Uint8Array>> {
     const headers = new Headers(this.headers);
-    headers.set("Range", `bytes=${offset}-${offset + length - 1}`);
+    if (length < 0) {
+      headers.set("Range", `bytes=${length}`);
+    } else {
+      headers.set("Range", `bytes=${offset}-${offset + length - 1}`);
+    }
 
     const cache: RequestCache = "no-store";
 
@@ -258,6 +275,16 @@ class FetchRangeLoader extends BaseLoader {
     }
 
     if (resp.status != 206) {
+      if (length < 0) {
+        // attempt to get full length and try non-negative range
+        const totalLength = await this.getLength();
+        return await this.getRange(
+          totalLength + length,
+          -length,
+          streaming,
+          signal,
+        );
+      }
       const info = { url: this.url, status: resp.status, resp };
 
       if (resp.status === 401) {
@@ -267,6 +294,10 @@ class FetchRangeLoader extends BaseLoader {
       } else {
         throw new RangeError(info);
       }
+    }
+
+    if (this.length === null) {
+      this.parseLengthFromContentRange(resp.headers);
     }
 
     if (streaming) {
@@ -280,13 +311,24 @@ class FetchRangeLoader extends BaseLoader {
     let backoff = 1000;
     for (let count = 0; count < 20; count++) {
       const resp = await fetch(url, options);
-      if (resp.status !== 429) {
+      if (resp.status !== 429 && resp.status !== 503) {
         return resp;
       }
       await sleep(backoff);
       backoff += 2000;
     }
     throw new Error("retryFetch failed");
+  }
+
+  parseLengthFromContentRange(headers: Headers) {
+    const range = headers.get("Content-Range");
+    if (range) {
+      const rangeParts = range.split("/");
+      if (rangeParts.length === 2) {
+        // @ts-expect-error [TODO] - TS2345 - Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
+        this.length = parseInt(rangeParts[1]);
+      }
+    }
   }
 }
 

--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -13,7 +13,16 @@ export async function initAutoIPFS(opts: Record<string, any>) {
     autoipfsAPI = await create(opts);
   }
 
-  // [TODO]
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return autoipfsAPI;
+  return autoipfsAPI as {
+    get: (
+      url: string,
+      opts: {
+        start?: number;
+        offset?: number;
+        end?: number;
+        signal?: AbortSignal | null;
+      },
+    ) => AsyncIterable<Uint8Array>;
+    getSize: (url: string) => number | null;
+  };
 }

--- a/src/wacz/ziprangereader.ts
+++ b/src/wacz/ziprangereader.ts
@@ -100,15 +100,16 @@ export class ZipRangeReader {
 
   async load(always = false): Promise<Record<string, ZipEntry>> {
     if (!this.entries || always) {
-      const totalLength = await this.loader.getLength();
-
-      const length = Math.min(MAX_INT16 + 23, totalLength);
-      const start = totalLength - length;
-      const endChunk = (await this.loader.getRange(
-        start,
-        length,
+      const endChunkOffset = MAX_INT16 + 23;
+      const endChunk = (await this.loader.getRangeFromEnd(
+        endChunkOffset,
         false,
       )) as Uint8Array;
+
+      const start = Math.max(
+        (await this.loader.getLength()) - endChunkOffset,
+        0,
+      );
 
       try {
         this.entries = this._loadEntries(endChunk, start);


### PR DESCRIPTION
- avoid extra getLength() call if loader supports negative ranges from end!
- add getNegativeRange(), which will use negative range lookup if supported - so far, only FetchRangeLoader
- otherwise, call getLength() to compute offset from end
- use getNegativeRange() in ZipRangeReader for loading WACZ files
- bump to 2.21.3