### PR TITLE
Improved support for proxy origin replay mode

### DIFF
--- a/.github/workflows/make-draft-release.yaml
+++ b/.github/workflows/make-draft-release.yaml
@@ -1,0 +1,26 @@
+name: Generate Draft Release
+
+on:
+  push:
+    branches:
+      - main
+      - "*-release"
+
+jobs:
+  package_chart:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+
+      - name: Get Version
+        run: |
+          echo "version=$(jq -r .version package.json)" >> "$GITHUB_ENV"
+
+      - name: Make Draft Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "wabac.js v${{ env.version }}"
+          tag_name: v${{ env.version }}
+          draft: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.21.3",
+  "version": "2.21.4",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.21.4",
+  "version": "2.22.0",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.22.0",
+  "version": "2.22.0-beta.0",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/archivedb.ts
+++ b/src/archivedb.ts
@@ -396,6 +396,10 @@ export class ArchiveDB implements DBStore {
     return await this.db!.getAll("pages");
   }
 
+  async getPagesByUrl(url: string) {
+    return await this.db!.getAllFromIndex("pages", "url", url);
+  }
+
   async getPages(pages: string[]) {
     const results: PageEntry[] = [];
     pages.sort();

--- a/src/blockloaders.ts
+++ b/src/blockloaders.ts
@@ -220,7 +220,7 @@ class FetchRangeLoader extends BaseLoader {
           this.length = json.size;
         }
       } catch (e) {
-        console.log("Error fetching from helper: " + e!.toString());
+        console.log("Error fetching from helper: " + e);
       }
     }
 
@@ -780,7 +780,7 @@ class IPFSRangeLoader extends BaseLoader {
     if (tryHead || !this.isValid) {
       body = new Uint8Array([]);
     } else {
-      const iter = autoipfsClient.get(this.url, {
+      const iter: AsyncIterable<Uint8Array> = autoipfsClient.get(this.url, {
         signal,
       });
       body = getReadableStreamFromIter(iter);
@@ -799,7 +799,7 @@ class IPFSRangeLoader extends BaseLoader {
   ) {
     const autoipfsClient = await initAutoIPFS(this.opts);
 
-    const iter = autoipfsClient.get(this.url, {
+    const iter: AsyncIterable<Uint8Array> = autoipfsClient.get(this.url, {
       start: offset,
       end: offset + length - 1,
       signal,

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -331,8 +331,7 @@ export class Collection {
   wbinfo.url = "${url}";
   wbinfo.timestamp = "${timestamp}";
   wbinfo.request_ts = "${requestTS}";
-  wbinfo.mod = "id_";
-  wbinfo.coll = "${this.name}";
+  self.__wbinfo = wbinfo;
 </script>
 <script src="${this.proxyPrefix}${this.proxyBannerUrl}"></script>
 <!-- End WB Insert -->

--- a/src/request.ts
+++ b/src/request.ts
@@ -4,7 +4,7 @@ const REPLAY_REGEX =
   /^(?::([\w-]+)\/)?(\d*)([a-z]+_|[$][a-z0-9:.-]+)?(?:\/|\||%7C|%7c)(.+)/;
 
 export type ArchiveRequestInitOpts = {
-  isRoot?: boolean,
+  isRoot?: boolean;
   mod?: string;
   ts?: string;
   proxyOrigin?: string;
@@ -39,7 +39,7 @@ export class ArchiveRequest {
       ts = "",
       proxyOrigin = undefined,
       localOrigin = undefined,
-    } : ArchiveRequestInitOpts = {},
+    }: ArchiveRequestInitOpts = {},
   ) {
     const wbUrl = REPLAY_REGEX.exec(wbUrlStr);
 

--- a/src/request.ts
+++ b/src/request.ts
@@ -20,6 +20,8 @@ export class ArchiveRequest {
   cookie = "";
 
   isProxyOrigin = false;
+  proxyOrigin?: string;
+  localOrigin?: string;
 
   request: Request;
   method: string;
@@ -82,6 +84,8 @@ export class ArchiveRequest {
         );
       }
       this.isProxyOrigin = true;
+      this.proxyOrigin = proxyOrigin;
+      this.localOrigin = localOrigin;
     }
 
     const hashIndex = this.url.indexOf("#");

--- a/src/request.ts
+++ b/src/request.ts
@@ -9,6 +9,7 @@ export type ArchiveRequestInitOpts = {
   ts?: string;
   proxyOrigin?: string;
   localOrigin?: string;
+  defaultReplayMode?: boolean;
 };
 
 export class ArchiveRequest {
@@ -41,6 +42,7 @@ export class ArchiveRequest {
       ts = "",
       proxyOrigin = undefined,
       localOrigin = undefined,
+      defaultReplayMode = false,
     }: ArchiveRequestInitOpts = {},
   ) {
     const wbUrl = REPLAY_REGEX.exec(wbUrlStr);
@@ -66,15 +68,12 @@ export class ArchiveRequest {
       return;
     } else {
       this.pageId = wbUrl[1] || "";
-      // @ts-expect-error [TODO] - TS2322 - Type 'string | undefined' is not assignable to type 'string'.
-      this.timestamp = wbUrl[2];
-      // @ts-expect-error [TODO] - TS2322 - Type 'string | undefined' is not assignable to type 'string'.
-      this.mod = wbUrl[3];
-      // @ts-expect-error [TODO] - TS2322 - Type 'string | undefined' is not assignable to type 'string'.
-      this.url = wbUrl[4];
+      this.timestamp = wbUrl[2] || "";
+      this.mod = wbUrl[3] || "";
+      this.url = wbUrl[4] || "";
     }
 
-    if (proxyOrigin && localOrigin) {
+    if (proxyOrigin && localOrigin && !defaultReplayMode) {
       this.url = resolveProxyOrigin(proxyOrigin, localOrigin, this.url);
       if (this.request.referrer) {
         this._proxyReferrer = resolveProxyOrigin(
@@ -171,9 +170,7 @@ export class ArchiveRequest {
     if (url.startsWith("//") && referrer) {
       try {
         url = new URL(referrer).protocol + url;
-        // [TODO]
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (e) {
+      } catch (_) {
         url = "https:" + url;
       }
     }

--- a/src/request.ts
+++ b/src/request.ts
@@ -3,6 +3,14 @@ import { postToGetUrl } from "warcio";
 const REPLAY_REGEX =
   /^(?::([\w-]+)\/)?(\d*)([a-z]+_|[$][a-z0-9:.-]+)?(?:\/|\||%7C|%7c)(.+)/;
 
+export type ArchiveRequestInitOpts = {
+  isRoot?: boolean,
+  mod?: string;
+  ts?: string;
+  proxyOrigin?: string;
+  localOrigin?: string;
+};
+
 export class ArchiveRequest {
   url = "";
   timestamp = "";
@@ -17,6 +25,7 @@ export class ArchiveRequest {
   method: string;
   mode: string;
 
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly
   private _proxyReferrer = "";
 
   _postToGetConverted = false;
@@ -28,9 +37,9 @@ export class ArchiveRequest {
       isRoot = false,
       mod = "",
       ts = "",
-      proxyOrigin = null,
-      localOrigin = null,
-    } = {},
+      proxyOrigin = undefined,
+      localOrigin = undefined,
+    } : ArchiveRequestInitOpts = {},
   ) {
     const wbUrl = REPLAY_REGEX.exec(wbUrlStr);
 
@@ -63,8 +72,6 @@ export class ArchiveRequest {
       this.url = wbUrl[4];
     }
 
-    // [TODO]
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (proxyOrigin && localOrigin) {
       this.url = resolveProxyOrigin(proxyOrigin, localOrigin, this.url);
       if (this.request.referrer) {

--- a/src/rewrite/html.ts
+++ b/src/rewrite/html.ts
@@ -568,23 +568,19 @@ export class ProxyHTMLRewriter extends HTMLRewriter {
     forceAbs = false,
     mod = "",
   ) {
-    if (!["ln_", "fr_", "if_"].includes(mod)) {
-      return text;
-    }
-
     if (mod === "if_" || mod === "fr_") {
       return (rewriter as ProxyRewriter).directRewriteUrl(text, forceAbs);
     }
 
-    // if html charset not utf-8, just convert the url to utf-8 for rewriting
-    if (!this.isCharsetUTF8) {
-      text = decoder.decode(encodeLatin1(text));
+    if (mod === "ln_") {
+      // if html charset not utf-8, just convert the url to utf-8 for rewriting
+      if (!this.isCharsetUTF8) {
+        text = decoder.decode(encodeLatin1(text));
+      }
+
+      return rewriter.rewriteUrl(text, forceAbs);
     }
 
-    const res = rewriter.rewriteUrl(text, forceAbs);
-
-    return mod && mod !== defmod && mod !== "ln_"
-      ? res.replace(defmod + "/", mod + "/")
-      : res;
+    return text;
   }
 }

--- a/src/rewrite/html.ts
+++ b/src/rewrite/html.ts
@@ -7,7 +7,7 @@ import {
   MAX_STREAM_CHUNK_SIZE,
   REPLAY_TOP_FRAME_NAME,
 } from "../utils";
-import { type ArchiveResponse, type BaseRewriter } from "./index.js";
+import { type ArchiveResponse, type Rewriter } from "./index.js";
 import { type StartTag } from "parse5-sax-parser";
 import { type Token } from "parse5";
 
@@ -91,12 +91,12 @@ const TEXT_NODE_REWRITE_RULES: TextNodeRewriteRule[] = [
 
 // ===========================================================================
 export class HTMLRewriter {
-  rewriter: BaseRewriter;
+  rewriter: Rewriter;
   rule: TextNodeRewriteRule | null = null;
   ruleMatch: RegExpMatchArray | null = null;
   isCharsetUTF8: boolean;
 
-  constructor(rewriter: BaseRewriter, isCharsetUTF8 = false) {
+  constructor(rewriter: Rewriter, isCharsetUTF8 = false) {
     this.rewriter = rewriter;
     this.rule = null;
 
@@ -115,7 +115,7 @@ export class HTMLRewriter {
   rewriteMetaContent(
     attrs: Token.Attribute[],
     attr: Token.Attribute,
-    rewriter: BaseRewriter,
+    rewriter: Rewriter,
   ) {
     let equiv = this.getAttr(attrs, "http-equiv");
     if (equiv) {
@@ -140,7 +140,7 @@ export class HTMLRewriter {
     return attr.value;
   }
 
-  rewriteSrcSet(value: string, rewriter: BaseRewriter) {
+  rewriteSrcSet(value: string, rewriter: Rewriter) {
     const SRCSET_REGEX = /\s*(\S*\s+[\d.]+[wx]),|(?:\s*,(?:\s+|(?=https?:)))/;
 
     const rv: string[] = [];
@@ -160,7 +160,7 @@ export class HTMLRewriter {
   rewriteTagAndAttrs(
     tag: StartTag,
     attrRules: Record<string, string>,
-    rewriter: BaseRewriter,
+    rewriter: Rewriter,
   ) {
     const isUrl = (val: string) => {
       return startsWithAny(val, DATA_RW_PROTOCOLS);
@@ -522,7 +522,7 @@ export class HTMLRewriter {
     return response;
   }
 
-  rewriteUrl(rewriter: BaseRewriter, text: string, forceAbs = false, mod = "") {
+  rewriteUrl(rewriter: Rewriter, text: string, forceAbs = false, mod = "") {
     // if html charset not utf-8, just convert the url to utf-8 for rewriting
     if (!this.isCharsetUTF8) {
       text = decoder.decode(encodeLatin1(text));
@@ -547,7 +547,7 @@ export class HTMLRewriter {
     return text;
   }
 
-  rewriteJSBase64(text: string, rewriter: BaseRewriter) {
+  rewriteJSBase64(text: string, rewriter: Rewriter) {
     const parts = text.split(",");
     // @ts-expect-error [TODO] - TS2769 - No overload matches this call.
     const content = rewriter.rewriteJS(atob(parts[1]), { isModule: false });
@@ -559,7 +559,7 @@ export class HTMLRewriter {
 // ===========================================================================
 export class ProxyHTMLRewriter extends HTMLRewriter {
   override rewriteUrl(
-    rewriter: BaseRewriter,
+    rewriter: Rewriter,
     text: string,
     forceAbs = false,
     mod = "",

--- a/src/rewrite/html.ts
+++ b/src/rewrite/html.ts
@@ -7,7 +7,7 @@ import {
   MAX_STREAM_CHUNK_SIZE,
   REPLAY_TOP_FRAME_NAME,
 } from "../utils";
-import { type ArchiveResponse, type Rewriter } from "./index.js";
+import { type ArchiveResponse, type BaseRewriter } from "./index.js";
 import { type StartTag } from "parse5-sax-parser";
 import { type Token } from "parse5";
 
@@ -24,7 +24,7 @@ const defmod = "mp_";
 const MAX_HTML_REWRITE_SIZE = 50000000;
 
 const rewriteTags: Record<string, Record<string, string>> = {
-  a: { href: defmod },
+  a: { href: "ln_" },
   applet: {
     codebase: "oe_",
     archive: "oe_",
@@ -90,13 +90,13 @@ const TEXT_NODE_REWRITE_RULES: TextNodeRewriteRule[] = [
 ];
 
 // ===========================================================================
-class HTMLRewriter {
-  rewriter: Rewriter;
+export class HTMLRewriter {
+  rewriter: BaseRewriter;
   rule: TextNodeRewriteRule | null = null;
   ruleMatch: RegExpMatchArray | null = null;
   isCharsetUTF8: boolean;
 
-  constructor(rewriter: Rewriter, isCharsetUTF8 = false) {
+  constructor(rewriter: BaseRewriter, isCharsetUTF8 = false) {
     this.rewriter = rewriter;
     this.rule = null;
 
@@ -115,7 +115,7 @@ class HTMLRewriter {
   rewriteMetaContent(
     attrs: Token.Attribute[],
     attr: Token.Attribute,
-    rewriter: Rewriter,
+    rewriter: BaseRewriter,
   ) {
     let equiv = this.getAttr(attrs, "http-equiv");
     if (equiv) {
@@ -140,7 +140,7 @@ class HTMLRewriter {
     return attr.value;
   }
 
-  rewriteSrcSet(value: string, rewriter: Rewriter) {
+  rewriteSrcSet(value: string, rewriter: BaseRewriter) {
     const SRCSET_REGEX = /\s*(\S*\s+[\d.]+[wx]),|(?:\s*,(?:\s+|(?=https?:)))/;
 
     const rv: string[] = [];
@@ -160,7 +160,7 @@ class HTMLRewriter {
   rewriteTagAndAttrs(
     tag: StartTag,
     attrRules: Record<string, string>,
-    rewriter: Rewriter,
+    rewriter: BaseRewriter,
   ) {
     const isUrl = (val: string) => {
       return startsWithAny(val, DATA_RW_PROTOCOLS);
@@ -285,13 +285,27 @@ class HTMLRewriter {
         name === "src" &&
         (tagName === "iframe" || tagName === "frame")
       ) {
-        const mod = attrRules[name];
-        attr.value = this.rewriteUrl(rewriter, attr.value, false, mod);
+        attr.value = this.rewriteUrl(
+          rewriter,
+          attr.value,
+          false,
+          attrRules[name],
+        );
       } else if (name === "href" || name === "src") {
-        attr.value = this.rewriteUrl(rewriter, attr.value);
+        attr.value = this.rewriteUrl(
+          rewriter,
+          attr.value,
+          false,
+          attrRules[name],
+        );
       } else {
         if (attrRules[attr.name]) {
-          attr.value = this.rewriteUrl(rewriter, attr.value);
+          attr.value = this.rewriteUrl(
+            rewriter,
+            attr.value,
+            false,
+            attrRules[name],
+          );
         }
       }
     }
@@ -444,12 +458,8 @@ class HTMLRewriter {
           isTextEmpty = isTextEmpty && textToken.text.trim().length === 0;
 
           if (scriptRw === "js" || isModule) {
-            // [TODO]
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
             return rewriter.rewriteJS(textToken.text, { isModule, prefix });
           } else if (scriptRw === "json") {
-            // [TODO]
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
             return rewriter.rewriteJSON(textToken.text, { prefix });
           } else if (scriptRw === "importmap") {
             return rewriter.rewriteImportmap(textToken.text);
@@ -464,8 +474,6 @@ class HTMLRewriter {
       })();
 
       for (let i = 0; i < text.length; i += MAX_STREAM_CHUNK_SIZE) {
-        // [TODO]
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         rwStream.emitRaw(text.slice(i, i + MAX_STREAM_CHUNK_SIZE));
       }
     });
@@ -514,13 +522,15 @@ class HTMLRewriter {
     return response;
   }
 
-  rewriteUrl(rewriter: Rewriter, text: string, forceAbs = false, mod = "") {
+  rewriteUrl(rewriter: BaseRewriter, text: string, forceAbs = false, mod = "") {
     // if html charset not utf-8, just convert the url to utf-8 for rewriting
     if (!this.isCharsetUTF8) {
       text = decoder.decode(encodeLatin1(text));
     }
     const res = rewriter.rewriteUrl(text, forceAbs);
-    return mod && mod !== defmod ? res.replace(defmod + "/", mod + "/") : res;
+    return mod && mod !== defmod && mod !== "ln_"
+      ? res.replace(defmod + "/", mod + "/")
+      : res;
   }
 
   rewriteHTMLText(text: string) {
@@ -537,15 +547,35 @@ class HTMLRewriter {
     return text;
   }
 
-  rewriteJSBase64(text: string, rewriter: Rewriter) {
+  rewriteJSBase64(text: string, rewriter: BaseRewriter) {
     const parts = text.split(",");
     // @ts-expect-error [TODO] - TS2769 - No overload matches this call.
     const content = rewriter.rewriteJS(atob(parts[1]), { isModule: false });
-    // [TODO]
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     parts[1] = btoa(content);
     return parts.join(",");
   }
 }
 
-export { HTMLRewriter };
+// ===========================================================================
+export class ProxyHTMLRewriter extends HTMLRewriter {
+  override rewriteUrl(
+    rewriter: BaseRewriter,
+    text: string,
+    forceAbs = false,
+    mod = "",
+  ) {
+    if (!["ln_", "fr_", "if_"].includes(mod)) {
+      return text;
+    }
+
+    // if html charset not utf-8, just convert the url to utf-8 for rewriting
+    if (!this.isCharsetUTF8) {
+      text = decoder.decode(encodeLatin1(text));
+    }
+
+    const res = rewriter.rewriteUrl(text, forceAbs);
+    return mod && mod !== defmod && mod !== "ln_"
+      ? res.replace(defmod + "/", mod + "/")
+      : res;
+  }
+}

--- a/src/rewrite/html.ts
+++ b/src/rewrite/html.ts
@@ -7,7 +7,11 @@ import {
   MAX_STREAM_CHUNK_SIZE,
   REPLAY_TOP_FRAME_NAME,
 } from "../utils";
-import { type ArchiveResponse, type Rewriter } from "./index.js";
+import {
+  type ProxyRewriter,
+  type ArchiveResponse,
+  type Rewriter,
+} from "./index.js";
 import { type StartTag } from "parse5-sax-parser";
 import { type Token } from "parse5";
 
@@ -568,12 +572,17 @@ export class ProxyHTMLRewriter extends HTMLRewriter {
       return text;
     }
 
+    if (mod === "if_" || mod === "fr_") {
+      return (rewriter as ProxyRewriter).directRewriteUrl(text, forceAbs);
+    }
+
     // if html charset not utf-8, just convert the url to utf-8 for rewriting
     if (!this.isCharsetUTF8) {
       text = decoder.decode(encodeLatin1(text));
     }
 
     const res = rewriter.rewriteUrl(text, forceAbs);
+
     return mod && mod !== defmod && mod !== "ln_"
       ? res.replace(defmod + "/", mod + "/")
       : res;

--- a/src/rewrite/index.ts
+++ b/src/rewrite/index.ts
@@ -817,6 +817,10 @@ export class ProxyRewriter extends Rewriter {
     return this.localOrigin + urlStr.slice(this.proxyOrigin.length);
   }
 
+  directRewriteUrl(urlStr: string, forceAbs = false) {
+    return super.rewriteUrl(urlStr, forceAbs);
+  }
+
   override async rewriteHtml(
     response: ArchiveResponse,
   ): Promise<ArchiveResponse> {

--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -224,28 +224,16 @@ export class SWReplay {
 
     this.proxyOriginMode = !!sp.get("proxyOriginMode");
 
-    this.replayPrefix = this.prefix;
-
-    let replayPrefixPath = "w";
-
     if (this.proxyOriginMode) {
+      this.replayPrefix = this.prefix + "__wb_proxy/";
+      this.staticPrefix = this.replayPrefix + "static/";
       this.proxyPrefix = "https://wab.ac/proxy/";
       this.apiPrefix = "https://wab.ac/api/";
-      replayPrefixPath = "__wb_proxy";
-      this.staticPrefix = this.prefix + "/" + replayPrefixPath + "static/";
     } else {
-      this.replayPrefix = this.prefix;
+      this.replayPrefix = this.prefix + (sp.get("replayPrefix") || "w") + "/";
       this.staticPrefix = this.prefix + "static/";
       this.proxyPrefix = this.staticPrefix + "proxy/";
       this.apiPrefix = this.replayPrefix + "api/";
-
-      if (sp.has("replayPrefix")) {
-        replayPrefixPath = sp.get("replayPrefix")!;
-      }
-    }
-
-    if (replayPrefixPath) {
-      this.replayPrefix += replayPrefixPath + "/";
     }
 
     this.distPrefix = this.prefix + "dist/";

--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -406,7 +406,7 @@ export class SWReplay {
   }
 
   async staticPathProxy(url: string, request: Request) {
-    url = url.slice((this.proxyPrefix).length);
+    url = url.slice(this.proxyPrefix.length);
     url = new URL(url, self.location.href).href;
     request = new Request(url);
     return this.defaultFetch(request, "no-store");
@@ -416,7 +416,10 @@ export class SWReplay {
     const opts: RequestInit = {};
     if (cache) {
       opts.cache = cache;
-    } else if (request.cache === "only-if-cached" && request.mode !== "same-origin") {
+    } else if (
+      request.cache === "only-if-cached" &&
+      request.mode !== "same-origin"
+    ) {
       opts.cache = "default";
     }
     return self.fetch(request, opts);
@@ -529,7 +532,7 @@ export class SWReplay {
       ? request.url
       : request.url.substring(coll.prefix.length);
 
-    const opts: ArchiveRequestInitOpts  = {
+    const opts: ArchiveRequestInitOpts = {
       isRoot: !!this.collections.root,
     };
 

--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -527,6 +527,8 @@ export class SWReplay {
       opts.mod = "id_";
       // @ts-expect-error [TODO] - TS4111 - Property 'proxyOrigin' comes from an index signature, so it must be accessed with ['proxyOrigin']. | TS4111 - Property 'extraConfig' comes from an index signature, so it must be accessed with ['extraConfig'].
       opts.proxyOrigin = coll.config.extraConfig.proxyOrigin;
+      // @ts-expect-error [TODO] - TS4111 - Property 'proxyTs' comes from an index signature, so it must be accessed with ['proxyOrigin']. | TS4111 - Property 'extraConfig' comes from an index signature, so it must be accessed with ['extraConfig'].
+      opts.ts = coll.config.extraConfig.proxyTs || "";
       // @ts-expect-error [TODO] - TS4111 - Property 'localOrigin' comes from an index signature, so it must be accessed with ['localOrigin'].
       opts.localOrigin = self.location.origin;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,7 +143,7 @@ export type ExtraConfig = {
 
   proxyOrigin?: string;
   proxyTs?: string;
-  proxyHeadInsert?: string;
+  proxyBannerUrl?: string;
 };
 
 export type CollConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,10 @@ export type ExtraConfig = {
 
   liveRedirectOnNotFound?: boolean;
   adblockUrl?: string;
+
+  proxyOrigin?: string;
+  proxyTs?: string;
+  proxyHeadInsert?: string;
 };
 
 export type CollConfig = {

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -100,6 +100,7 @@ export class MultiWACZ
 
   pagesQueryUrl = "";
   referrerMap = new Map<string, string>();
+  notAPage = new Set<string>();
 
   totalPages?: number = undefined;
 
@@ -1384,7 +1385,7 @@ export class MultiWACZ
     }
 
     // finally, fall back to all wacz files if no other choice
-    return Object.keys(this.waczfiles);
+    return Object.keys(this.waczfiles).slice(0, 3);
   }
 
   async getWACZFilesForPagesQuery(
@@ -1400,6 +1401,10 @@ export class MultiWACZ
     }
     if (selectFiles.length) {
       return selectFiles;
+    }
+
+    if (this.notAPage.has(requestUrl)) {
+      return null;
     }
 
     const params = new URLSearchParams();
@@ -1434,6 +1439,7 @@ export class MultiWACZ
       }
     }
     if (!selectFiles.length) {
+      this.notAPage.add(requestUrl);
       return null;
     }
 

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1403,7 +1403,7 @@ export class MultiWACZ
     }
 
     // finally, fall back to all wacz files if no other choice
-    return Object.keys(this.waczfiles).slice(0, 3);
+    return Object.keys(this.waczfiles);
   }
 
   async getWACZFilesForPagesQuery(

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1378,16 +1378,13 @@ export class MultiWACZ
         const res = this.seedPageWACZs.get(file.crawlId);
         if (res) {
           names = [...names, ...res.values()];
+          return names;
         }
       }
     }
 
-    // finally if 3 or less WACZ files, just try all of them
-    if (!names.length && Object.keys(this.waczfiles).length <= 3) {
-      names = Object.keys(this.waczfiles);
-    }
-
-    return names;
+    // finally, fall back to all wacz files if no other choice
+    return Object.keys(this.waczfiles);
   }
 
   async getWACZFilesForPagesQuery(

--- a/test/rewriteHTML.ts
+++ b/test/rewriteHTML.ts
@@ -105,7 +105,7 @@ test(
 test(
   rewriteHtml,
   '<body x="y"><img src="../img.gif"/><br/></body>',
-  '<body x="y"><img src="http://localhost:8080/prefix/20201226101010mp_/https://example.com/some/img.gif"/><br/></body>',
+  '<body x="y"><img src="http://localhost:8080/prefix/20201226101010im_/https://example.com/some/img.gif"/><br/></body>',
 );
 
 test(
@@ -134,7 +134,7 @@ test(
   "BASE tag",
   rewriteHtml,
   '<base href="//example.com"/><img src="/foo.gif"/>',
-  '<base href="//localhost:8080/prefix/20201226101010mp_///example.com/"/><img src="/prefix/20201226101010mp_/https://example.com/foo.gif"/>',
+  '<base href="//localhost:8080/prefix/20201226101010mp_///example.com/"/><img src="/prefix/20201226101010im_/https://example.com/foo.gif"/>',
 );
 
 test(

--- a/test/rewriteHTML.ts
+++ b/test/rewriteHTML.ts
@@ -52,8 +52,7 @@ const rewriteHtml = test.macro({
 // ===========================================================================
 
 // ===========================================================================
-// @ts-expect-error [TODO] - TS7006 - Parameter 'text' implicitly has an 'any' type.
-function wrapScript(text) {
+function wrapScript(text: string) {
   return `\
 var _____WB$wombat$assign$function_____ = function(name) {return (self._wb_wombat && self._wb_wombat.local_init && self._wb_wombat.local_init(name)) || self[name]; };
 if (!self.__WB_pmw) { self.__WB_pmw = function(obj) { this.__WB_source = obj; return this; } }
@@ -74,16 +73,14 @@ ${text}
 }`;
 }
 
-// @ts-expect-error [TODO] - TS7006 - Parameter 'text' implicitly has an 'any' type.
-function wrapScriptInline(text) {
+function wrapScriptInline(text: string) {
   return wrapScript(text)
     .replace(/\n/g, " ")
     .replace(/["]/g, "&quot;")
     .replace(/[&][&]/g, "&amp;&amp;");
 }
 
-// @ts-expect-error [TODO] - TS7006 - Parameter 'text' implicitly has an 'any' type.
-function wrapScriptModule(text) {
+function wrapScriptModule(text: string) {
   return `\
 <script type="module">import { window, globalThis, self, document, location, top, parent, frames, opener } from "http://localhost:8080/prefix/20201226101010mp_/__wb_module_decl.js";
 ${text}</script>`;


### PR DESCRIPTION
Fix / improve support for proxy origin mode:
- proxy mode rewriting applied, ensure headers and links to proxy origin are rewritten to local origin
- normal rewriting more for iframes
- support for banner, specified via extraConfig.proxyBannerUrl

rewriting: use more specific modifier to assist proxy origin rewriting for links, iframes, add ln_ modifier for internal use.

MultiWACZ + proxy origin tweaks:
- if page not found and has www., try without www.
- keep track of referrer to determine page for MultiWACZ
- if lookup from multiple WACZs, find best response by timestamp distance correctly.
- as fallback, try all WACZ files, fix nested MultiWACZ replay

ci: add draft release ci action
bump to 2.22.0-beta.0