### PR TITLE
multiwacz: allow looking through all WACZ files only for nested WACZ …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -102,6 +102,8 @@ export class MultiWACZ
   referrerMap = new Map<string, string>();
   notAPage = new Set<string>();
 
+  maxFallbackLookups = 3;
+
   totalPages?: number = undefined;
 
   preloadResources: string[] = [];
@@ -1403,7 +1405,11 @@ export class MultiWACZ
     }
 
     // finally, fall back to all wacz files if no other choice
-    return Object.keys(this.waczfiles);
+    const allFiles = Object.keys(this.waczfiles);
+    if (this.maxFallbackLookups > 0) {
+      return allFiles.slice(0, this.maxFallbackLookups);
+    }
+    return allFiles;
   }
 
   async getWACZFilesForPagesQuery(

--- a/src/wacz/waczimporter.ts
+++ b/src/wacz/waczimporter.ts
@@ -163,6 +163,8 @@ export class WACZImporter {
     this.file.markAsMultiWACZ();
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     await this.store.loadWACZFiles(root, this.file);
+
+    this.store.maxFallbackLookups = -1;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return root;
   }


### PR DESCRIPTION
…files (which do not have a page list currently)

otherwise, default to 3 WACZ file lookups as before
bump to 2.22.1