### PR TITLE
Proxy TLD Rewriting + Proxy 'mini-wombat' banner inject

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.22.2",
+  "version": "2.22.3",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -225,7 +225,6 @@ export class Collection {
           request,
           response,
           baseUrl,
-          requestURL,
           requestTS,
         );
       }
@@ -314,14 +313,15 @@ export class Collection {
     request: ArchiveRequest,
     response: ArchiveResponse,
     baseUrl: string,
-    requestURL: string,
     requestTS: string,
   ) {
     const basePrefix =
       this.prefix + (request.pageId ? `:${request.pageId}/` : "");
-    const basePrefixTS = basePrefix + requestTS;
 
     const timestamp = getTS(response.date.toISOString());
+
+    // default to requestTS if any, otherwise us actual ts for iframe rw
+    const basePrefixTS = basePrefix + (requestTS || timestamp);
 
     const headInsertFunc = (url: string) => {
       return `
@@ -329,13 +329,13 @@ export class Collection {
 <script>
   const wbinfo = {};
   wbinfo.url = "${url}";
-  wbinfo.timestamp = "${timestamp}";
   wbinfo.request_ts = "${requestTS}";
+  wbinfo.timestamp = "${timestamp}";
   wbinfo.proxyOrigin = "${request.proxyOrigin || ""}";
   wbinfo.localOrigin = "${request.localOrigin || ""}";
   wbinfo.localTLD = "${request.localTLD || ""}";
   wbinfo.proxyTLD = "${request.proxyTLD || ""}";
-  wbinfo.prefix = "${prefix}";
+  wbinfo.prefix = "${basePrefixTS}";
   self.__wbinfo = wbinfo;
 </script>
 <script src="${this.staticPrefix}wombatProxy.js"></script>

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -335,6 +335,7 @@ export class Collection {
   wbinfo.localOrigin = "${request.localOrigin || ""}";
   wbinfo.localTLD = "${request.localTLD || ""}";
   wbinfo.proxyTLD = "${request.proxyTLD || ""}";
+  wbinfo.prefix = "${prefix}";
   self.__wbinfo = wbinfo;
 </script>
 <script src="${this.staticPrefix}wombatProxy.js"></script>

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -331,8 +331,13 @@ export class Collection {
   wbinfo.url = "${url}";
   wbinfo.timestamp = "${timestamp}";
   wbinfo.request_ts = "${requestTS}";
+  wbinfo.proxyOrigin = "${request.proxyOrigin || ""}";
+  wbinfo.localOrigin = "${request.localOrigin || ""}";
+  wbinfo.localTLD = "${request.localTLD || ""}";
+  wbinfo.proxyTLD = "${request.proxyTLD || ""}";
   self.__wbinfo = wbinfo;
 </script>
+<script src="${this.staticPrefix}wombatProxy.js"></script>
 <script src="${this.proxyPrefix}${this.proxyBannerUrl}"></script>
 <!-- End WB Insert -->
     `;

--- a/src/request.ts
+++ b/src/request.ts
@@ -9,6 +9,8 @@ export type ArchiveRequestInitOpts = {
   ts?: string;
   proxyOrigin?: string;
   localOrigin?: string;
+  proxyTLD?: string;
+  localTLD?: string;
   defaultReplayMode?: boolean;
 };
 
@@ -23,6 +25,9 @@ export class ArchiveRequest {
   isProxyOrigin = false;
   proxyOrigin?: string;
   localOrigin?: string;
+
+  proxyTLD?: string;
+  localTLD?: string;
 
   request: Request;
   method: string;
@@ -42,6 +47,7 @@ export class ArchiveRequest {
       ts = "",
       proxyOrigin = undefined,
       localOrigin = undefined,
+      proxyTLD = undefined,
       defaultReplayMode = false,
     }: ArchiveRequestInitOpts = {},
   ) {
@@ -85,6 +91,7 @@ export class ArchiveRequest {
       this.isProxyOrigin = true;
       this.proxyOrigin = proxyOrigin;
       this.localOrigin = localOrigin;
+      this.proxyTLD = proxyTLD || "";
     }
 
     const hashIndex = this.url.indexOf("#");

--- a/src/request.ts
+++ b/src/request.ts
@@ -48,6 +48,7 @@ export class ArchiveRequest {
       proxyOrigin = undefined,
       localOrigin = undefined,
       proxyTLD = undefined,
+      localTLD = undefined,
       defaultReplayMode = false,
     }: ArchiveRequestInitOpts = {},
   ) {
@@ -92,6 +93,7 @@ export class ArchiveRequest {
       this.proxyOrigin = proxyOrigin;
       this.localOrigin = localOrigin;
       this.proxyTLD = proxyTLD || "";
+      this.localTLD = localTLD || "";
     }
 
     const hashIndex = this.url.indexOf("#");

--- a/src/rewrite/proxyinject.ts
+++ b/src/rewrite/proxyinject.ts
@@ -61,7 +61,10 @@ class ProxyWombatRewrite {
   processChangedNode(target: Node) {
     switch (target.nodeType) {
       case Node.ATTRIBUTE_NODE:
-        if (target.nodeName === "href") {
+        if (
+          target.nodeName === "href" &&
+          target.parentElement?.tagName === "A"
+        ) {
           const url = target.nodeValue;
           if (url) {
             console.log("rewriting " + url);

--- a/src/rewrite/proxyinject.ts
+++ b/src/rewrite/proxyinject.ts
@@ -1,0 +1,143 @@
+type WbInfo = {
+  proxyOrigin: string;
+  localOrigin: string;
+  proxyTLD?: string;
+  localTLD?: string;
+};
+
+// Mini Wombat for proxy -- Mutation Observer + window.open override
+
+class ProxyWombatRewrite {
+  mutationObserver: MutationObserver;
+
+  proxyOrigin: string;
+  localOrigin: string;
+
+  proxyTLD?: string;
+  localTLD?: string;
+  localScheme: string;
+
+  constructor() {
+    this.mutationObserver = new MutationObserver((changes) =>
+      this.observeChange(changes),
+    );
+
+    this.mutationObserver.observe(document.documentElement, {
+      characterData: false,
+      characterDataOldValue: false,
+      attributes: true,
+      attributeOldValue: false,
+      subtree: true,
+      childList: true,
+      attributeFilter: ["href"],
+    });
+
+    this.openOverride();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const wbinfo = (self as any).__wbinfo as WbInfo;
+
+    this.proxyOrigin = wbinfo.proxyOrigin;
+    this.localOrigin = wbinfo.localOrigin;
+
+    this.proxyTLD = wbinfo.proxyTLD;
+    this.localTLD = wbinfo.localTLD;
+
+    this.localScheme = new URL(this.localOrigin).protocol;
+  }
+
+  observeChange(changes: MutationRecord[]) {
+    for (const change of changes) {
+      this.processChangedNode(change.target);
+
+      if (change.type === "childList") {
+        for (const node of change.addedNodes) {
+          this.processChangedNode(node);
+        }
+      }
+    }
+  }
+
+  processChangedNode(target: Node) {
+    switch (target.nodeType) {
+      case Node.ATTRIBUTE_NODE:
+        if (target.nodeName === "href") {
+          const url = target.nodeValue;
+          if (url) {
+            console.log("rewriting " + url);
+            target.parentElement?.setAttribute(
+              target.nodeName,
+              this.rewriteUrl(url),
+            );
+          }
+        }
+        break;
+    }
+  }
+
+  openOverride() {
+    let orig = window.open;
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (Window.prototype.open) {
+      orig = Window.prototype.open;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const rewriter = this;
+
+    function openRW(
+      strUrl: string | URL | undefined,
+      strWindowName?: string,
+      strWindowFeatures?: string,
+    ): Window | null {
+      const rwStrUrl = strUrl ? rewriter.rewriteUrl(strUrl.toString()) : "";
+      const res = orig.call(
+        // @ts-ignore
+        this,
+        rwStrUrl,
+        strWindowName,
+        strWindowFeatures,
+      );
+      return res;
+    }
+
+    window.open = openRW;
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (Window.prototype.open) {
+      Window.prototype.open = openRW;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/prefer-for-of
+    for (let i = 0; i < window.frames.length; i++) {
+      try {
+        window.frames[i]!.open = openRW;
+      } catch (e) {
+        console.log(e);
+      }
+    }
+  }
+
+  rewriteUrl(urlStr: string) {
+    if (this.proxyOrigin && urlStr.startsWith(this.proxyOrigin)) {
+      return this.localOrigin + urlStr.slice(this.proxyOrigin.length);
+    }
+
+    if (this.proxyTLD && this.localTLD && urlStr.indexOf(this.proxyTLD) > 0) {
+      const url = new URL(urlStr);
+      if (url.host.endsWith(this.proxyTLD)) {
+        const host =
+          url.host.slice(0, -this.proxyTLD.length).replace(".", "-") +
+          this.localTLD;
+        const newUrl =
+          this.localScheme + "//" + host + url.href.slice(url.origin.length);
+        return newUrl;
+      }
+    }
+
+    return urlStr;
+  }
+}
+
+new ProxyWombatRewrite();

--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -546,6 +546,8 @@ export class SWReplay {
     if (this.proxyOriginMode && !defaultReplayMode) {
       opts.mod = "id_";
       opts.proxyOrigin = coll.config.extraConfig?.proxyOrigin;
+      opts.proxyTLD = coll.config.extraConfig?.proxyTLD;
+      opts.localTLD = coll.config.extraConfig?.localTLD;
       opts.ts = coll.config.extraConfig?.proxyTs || "";
       opts.localOrigin = self.location.origin;
     }

--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -8,6 +8,7 @@ import { API } from "./api";
 
 import WOMBAT from "../dist-wombat/wombat.txt";
 import WOMBAT_WORKERS from "../dist-wombat/wombatWorkers.txt";
+import WOMBAT_PROXY from "../dist-wombat/wombatProxy.txt";
 
 import { ArchiveRequest, type ArchiveRequestInitOpts } from "./request";
 import { type CollMetadata } from "./types";
@@ -246,6 +247,10 @@ export class SWReplay {
     this.staticData.set(this.staticPrefix + "wombatWorkers.js", {
       type: "application/javascript",
       content: WOMBAT_WORKERS,
+    });
+    this.staticData.set(this.staticPrefix + "wombatProxy.js", {
+      type: "application/javascript",
+      content: WOMBAT_PROXY,
     });
 
     if (sp.has("serveIndex")) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,9 @@ export type ExtraConfig = {
   liveRedirectOnNotFound?: boolean;
   adblockUrl?: string;
 
+  proxyTLD?: string;
+  localTLD?: string;
+
   proxyOrigin?: string;
   proxyTs?: string;
   proxyBannerUrl?: string;

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -14,6 +14,7 @@ const wombatBuild = {
   entry: {
     wombat: "@webrecorder/wombat/src/wbWombat.js",
     wombatWorkers: "@webrecorder/wombat/src/wombatWorkers.js",
+    wombatProxy: "./src/rewrite/proxyinject.ts"
   },
   output: {
     path: path.join(__dirname, "dist-wombat"),
@@ -29,6 +30,24 @@ const wombatBuild = {
       }),
     ],
   },
+
+  resolve: {
+    extensions: [".ts", ".js"],
+    plugins: [new TsconfigPathsPlugin()],
+  },
+
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: "ts-loader",
+        include: path.resolve(__dirname, "src"),
+        options: {
+          onlyCompileBundledFiles: false,
+        },
+      },
+    ]
+  }
 };
 
 const mainBuild = {
@@ -89,7 +108,7 @@ const mainBuild = {
         },
       },
       {
-        test: /(wombat.txt|wombatWorkers.txt)$/i,
+        test: /(wombat.*txt)$/i,
         use: "raw-loader",
       },
     ],


### PR DESCRIPTION
Support selective rewriting of all a.href links for subdomain given a TLD, mapping proxyTLD -> localTLD

Proxy Injection (mini-wombat):
- add src/rewrite/proxyinject.ts to be build into wombatProxy.js, injected into proxy mode replay
- support a.href rewriting for new links added (via dom override and window.open)
- rewriting of iframe.src to direct rewriting at closest timestamp, using dom override

bump to 2.22.3