### PR TITLE
More proxy rewriting fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.22.3",
+  "version": "2.22.4",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/rewrite/html.ts
+++ b/src/rewrite/html.ts
@@ -285,32 +285,13 @@ export class HTMLRewriter {
         ) {
           attr.value = REPLAY_TOP_FRAME_NAME;
         }
-      } else if (
-        name === "src" &&
-        (tagName === "iframe" || tagName === "frame")
-      ) {
+      } else if (attrRules[name] || name === "href" || name === "src") {
         attr.value = this.rewriteUrl(
           rewriter,
           attr.value,
           false,
           attrRules[name],
         );
-      } else if (name === "href" || name === "src") {
-        attr.value = this.rewriteUrl(
-          rewriter,
-          attr.value,
-          false,
-          attrRules[name],
-        );
-      } else {
-        if (attrRules[attr.name]) {
-          attr.value = this.rewriteUrl(
-            rewriter,
-            attr.value,
-            false,
-            attrRules[name],
-          );
-        }
       }
     }
   }
@@ -582,5 +563,27 @@ export class ProxyHTMLRewriter extends HTMLRewriter {
     }
 
     return text;
+  }
+
+  override rewriteTagAndAttrs(
+    tag: StartTag,
+    attrRules: Record<string, string>,
+    rewriter: Rewriter,
+  ) {
+    const tagName = tag.tagName;
+
+    // no attribute rewriting for web-component tags, which must contain a '-'
+    if (tagName.indexOf("-") > 0) {
+      return;
+    }
+
+    for (const attr of tag.attrs) {
+      const name = attr.name || "";
+      const value = attr.value || "";
+
+      if (attrRules[name] || name === "href" || name === "src") {
+        attr.value = this.rewriteUrl(rewriter, value, false, attrRules[name]);
+      }
+    }
   }
 }

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1219,8 +1219,7 @@ export class MultiWACZ
       resp = await super.getResource(request, prefix, event, {
         // @ts-expect-error [TODO] - TS2345 - Argument of type '{ waczname: string; noFuzzyCheck: true; loadFirst: boolean; }' is not assignable to parameter of type 'Opts'.
         waczname: name,
-        noFuzzyCheck: true,
-        loadFirst: true,
+        noFuzzyCheck: !request.isProxyOrigin,
       });
       if (resp) {
         const arResponse = resp as ArchiveResponse;


### PR DESCRIPTION
- attempt to rewrite links in html via regex
- simplify proxyhtmlrewriter to avoid extra attr manipulation
- add insertAdjacentHTML rewriting, DocumentFragment.append / prepend rewriting (via regex)
- don't set noFuzzyMatch flag for proxy mode lookup, as it's initial, not fallback
- bump to 2.22.4