### PR TITLE
Pass existing request parameters to `Request` constructor init parameter

### DIFF
--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -408,7 +408,7 @@ export class SWReplay {
   async staticPathProxy(url: string, request: Request) {
     url = url.slice(this.proxyPrefix.length);
     url = new URL(url, self.location.href).href;
-    request = new Request(url);
+    request = new Request(url, request);
     return this.defaultFetch(request, "no-store");
   }
 
@@ -435,7 +435,7 @@ export class SWReplay {
         continue;
       }
 
-      //console.log(`Auto Cacheing: ${url}`);
+      //console.log(`Auto Caching: ${url}`);
       try {
         response = await this.defaultFetch(new Request(url));
         await cache.put(url, response);


### PR DESCRIPTION
This ensures that all properties of the request, aside from the url, are carried over from the original request.

This is necessary for certain features of GovArchive.us, specifically usage data collection via Plausible.