### PR TITLE
Get static proxy working for non-GET requests

### DIFF
--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -185,6 +185,7 @@ type SWReplayInitOpts = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
     injectScripts?: string[];
+    adblockUrl?: string | null;
   };
   CollectionsClass?: typeof SWCollections;
 };
@@ -278,7 +279,6 @@ export class SWReplay {
     }
 
     if (sp.has("adblockUrl")) {
-      // @ts-expect-error [TODO] - TS4111 - Property 'adblockUrl' comes from an index signature, so it must be accessed with ['adblockUrl'].
       defaultConfig.adblockUrl = sp.get("adblockUrl");
     }
 
@@ -508,11 +508,9 @@ export class SWReplay {
     let collId = this.collections.root;
 
     if (!collId) {
-      // @ts-expect-error [TODO] - TS2322 - Type 'string | undefined' is not assignable to type 'string | null'.
-      collId = request.url.slice(this.replayPrefix.length).split("/", 1)[0];
+      collId = request.url.slice(this.replayPrefix.length).split("/", 1)[0]!;
     }
 
-    // @ts-expect-error [TODO] - TS2345 - Argument of type 'string | null' is not assignable to parameter of type 'string'.
     const coll = await this.collections.getColl(collId);
 
     // proxy origin, but no collection registered, just pass through to ensure setup is completed

--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -45,17 +45,15 @@ export class SWCollections extends WorkerLoader {
     this._fileHandles = {};
   }
 
-  // @ts-expect-error [TODO] - TS4114 - This member must have an 'override' modifier because it overrides a member in the base class 'WorkerLoader'.
   // [TODO]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _createCollection(opts: Record<string, any>): Collection {
+  override _createCollection(opts: Record<string, any>): Collection {
     return new Collection(opts, this.prefixes, this.defaultConfig);
   }
 
-  // @ts-expect-error [TODO] - TS4114 - This member must have an 'override' modifier because it overrides a member in the base class 'WorkerLoader'.
   // [TODO]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async loadAll(dbColl?: any): Promise<boolean> {
+  override async loadAll(dbColl?: any): Promise<boolean> {
     this.colls = {};
     // [TODO]
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -70,17 +68,15 @@ export class SWCollections extends WorkerLoader {
     return this.colls[name];
   }
 
-  // @ts-expect-error [TODO] - TS4114 - This member must have an 'override' modifier because it overrides a member in the base class 'WorkerLoader'.
-  async reload(name: string) {
+  override async reload(name: string) {
     delete this.colls[name];
 
     await this.getColl(name);
   }
 
-  // @ts-expect-error [TODO] - TS4114 - This member must have an 'override' modifier because it overrides a member in the base class 'WorkerLoader'.
   // [TODO]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async addCollection(data: any, progressUpdate: any) {
+  override async addCollection(data: any, progressUpdate: any) {
     // [TODO]
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const opts = await super.addCollection(data, progressUpdate);
@@ -92,8 +88,7 @@ export class SWCollections extends WorkerLoader {
     return opts;
   }
 
-  // @ts-expect-error [TODO] - TS4114 - This member must have an 'override' modifier because it overrides a member in the base class 'WorkerLoader'.
-  async deleteColl(name: string, keepFileHandle = false) {
+  override async deleteColl(name: string, keepFileHandle = false) {
     if (this.colls[name]) {
       // [TODO]
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -118,10 +113,13 @@ export class SWCollections extends WorkerLoader {
     return true;
   }
 
-  // @ts-expect-error [TODO] - TS4114 - This member must have an 'override' modifier because it overrides a member in the base class 'WorkerLoader'.
-  // [TODO]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async initNewColl(metadata: any, extraConfig = {}, type = "archive") {
+  override async initNewColl(
+    // [TODO]
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    metadata: any,
+    extraConfig = {},
+    type = "archive",
+  ) {
     // [TODO]
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const coll = await super.initNewColl(metadata, extraConfig, type);
@@ -133,8 +131,7 @@ export class SWCollections extends WorkerLoader {
     return coll;
   }
 
-  // @ts-expect-error [TODO] - TS4114 - This member must have an 'override' modifier because it overrides a member in the base class 'WorkerLoader'.
-  async updateAuth(name: string, headers: Record<string, string>) {
+  override async updateAuth(name: string, headers: Record<string, string>) {
     // [TODO]
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     if (this.colls[name] && (this.colls[name].store as any).updateHeaders) {
@@ -184,8 +181,11 @@ type SWReplayInitOpts = {
   staticData?: Map<string, any> | null;
   ApiClass?: typeof API;
   // [TODO]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  defaultConfig?: Record<string, any>;
+  defaultConfig?: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+    injectScripts?: string[];
+  };
   CollectionsClass?: typeof SWCollections;
 };
 
@@ -266,16 +266,12 @@ export class SWReplay {
 
     if (sp.has("injectScripts")) {
       const injectScripts = sp.get("injectScripts")!.split(",");
-      // @ts-expect-error [TODO] - TS4111 - Property 'injectScripts' comes from an index signature, so it must be accessed with ['injectScripts']. | TS4111 - Property 'injectScripts' comes from an index signature, so it must be accessed with ['injectScripts'].
       defaultConfig.injectScripts = defaultConfig.injectScripts
-        ? // @ts-expect-error [TODO] - TS4111 - Property 'injectScripts' comes from an index signature, so it must be accessed with ['injectScripts'].
-          [...injectScripts, ...defaultConfig.injectScripts]
+        ? [...injectScripts, ...defaultConfig.injectScripts]
         : injectScripts;
     }
 
-    // @ts-expect-error [TODO] - TS4111 - Property 'injectScripts' comes from an index signature, so it must be accessed with ['injectScripts'].
     if (defaultConfig.injectScripts) {
-      // @ts-expect-error [TODO] - TS4111 - Property 'injectScripts' comes from an index signature, so it must be accessed with ['injectScripts']. | TS4111 - Property 'injectScripts' comes from an index signature, so it must be accessed with ['injectScripts'].
       defaultConfig.injectScripts = defaultConfig.injectScripts.map(
         (url: string) => this.proxyPrefix + url,
       );

--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -12,6 +12,7 @@ import WOMBAT_PROXY from "../dist-wombat/wombatProxy.txt";
 
 import { ArchiveRequest, type ArchiveRequestInitOpts } from "./request";
 import { type CollMetadata } from "./types";
+import { staticPathProxy } from "./utils/staticPathProxy";
 
 const CACHE_PREFIX = "wabac-";
 const IS_AJAX_HEADER = "x-wabac-is-ajax-req";
@@ -211,6 +212,8 @@ export class SWReplay {
 
   stats: StatsTracker | null;
 
+  staticPathProxy: (url: string, request: Request) => Promise<Response>;
+
   constructor({
     staticData = null,
     ApiClass = API,
@@ -258,6 +261,8 @@ export class SWReplay {
       this.staticData.set(this.prefix, indexData);
       this.staticData.set(this.prefix + "index.html", indexData);
     }
+
+    this.staticPathProxy = staticPathProxy(this.proxyPrefix);
 
     if (sp.has("injectScripts")) {
       const injectScripts = sp.get("injectScripts")!.split(",");
@@ -403,13 +408,6 @@ export class SWReplay {
     } else {
       return this.defaultFetch(event.request);
     }
-  }
-
-  async staticPathProxy(url: string, request: Request) {
-    url = url.slice(this.proxyPrefix.length);
-    url = new URL(url, self.location.href).href;
-    request = new Request(url, request);
-    return this.defaultFetch(request, "no-store");
   }
 
   async defaultFetch(request: Request, cache?: RequestCache) {

--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -262,7 +262,7 @@ export class SWReplay {
       this.staticData.set(this.prefix + "index.html", indexData);
     }
 
-    this.staticPathProxy = staticPathProxy(this.proxyPrefix);
+    this.staticPathProxy = staticPathProxy(this.proxyPrefix, this.defaultFetch);
 
     if (sp.has("injectScripts")) {
       const injectScripts = sp.get("injectScripts")!.split(",");
@@ -410,11 +410,11 @@ export class SWReplay {
     }
   }
 
-  async defaultFetch(request: Request, cache?: RequestCache) {
-    const opts: RequestInit = {};
-    if (cache) {
-      opts.cache = cache;
-    } else if (
+  async defaultFetch(request: RequestInfo | URL, opts: RequestInit = {}) {
+    if (
+      !opts.cache &&
+      typeof request !== "string" &&
+      !(request instanceof URL) &&
       request.cache === "only-if-cached" &&
       request.mode !== "same-origin"
     ) {

--- a/src/utils/staticPathProxy.ts
+++ b/src/utils/staticPathProxy.ts
@@ -5,7 +5,7 @@ export const staticPathProxy =
     const headers = new Headers(request.headers);
     // Because of CORS restrictions, the request cannot be a ReadableStream, so instead we get it as a string.
     // If in the future we need to support streaming, we can revisit this — there may be a way to get it to work.
-    const body = await request.text();
+    const body = await request.arrayBuffer();
 
     url = url.slice(proxyPrefix.length);
     const urlObj = new URL(url, self.location.href);
@@ -15,7 +15,7 @@ export const staticPathProxy =
       cache: "no-store",
       headers,
       method,
-      ...(body && { body }),
+      ...(method !== "GET" && { body }),
     };
 
     return fetch(url, requestInit);

--- a/src/utils/staticPathProxy.ts
+++ b/src/utils/staticPathProxy.ts
@@ -2,7 +2,7 @@ export const staticPathProxy =
   (proxyPrefix: string, fetch: typeof self.fetch = self.fetch) =>
   async (url: string, request: Request) => {
     const method = request.method;
-    const headers = new Headers(request.headers);
+    const headers = request.headers;
     // Because of CORS restrictions, the request cannot be a ReadableStream, so instead we get it as a string.
     // If in the future we need to support streaming, we can revisit this — there may be a way to get it to work.
     const body = await request.arrayBuffer();

--- a/src/utils/staticPathProxy.ts
+++ b/src/utils/staticPathProxy.ts
@@ -1,0 +1,21 @@
+export const staticPathProxy =
+  (proxyPrefix: string) => async (url: string, request: Request) => {
+    const method = request.method;
+    const headers = new Headers(request.headers);
+    const body = request.body;
+    const mode = request.mode;
+
+    url = url.slice(proxyPrefix.length);
+    const urlObj = new URL(url, self.location.href);
+    url = urlObj.href;
+
+    headers.set("Host", urlObj.host);
+
+    return self.fetch(request, {
+      cache: "no-store",
+      headers,
+      method,
+      body,
+      mode,
+    });
+  };

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -3,6 +3,6 @@
     "noEmit": true
   },
   "extends": "./tsconfig.json",
-  "include": ["**/*.ts", "**/*.js", ".*.js"],
+  "include": ["**/*.ts", "**/*.js", ".*.js", "**/*.cjs"],
   "exclude": ["__generated__", "__mocks__", "dist"]
 }

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -3,10 +3,10 @@
 const path = require("path");
 const webpack = require("webpack");
 const TerserPlugin = require("terser-webpack-plugin");
-const CopyPlugin = require("copy-webpack-plugin");
 const package_json = require("./package.json");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
 
+/** @type {import("webpack").Configuration} */
 const wombatBuild = {
   name: "wombat",
   mode: "production",
@@ -14,7 +14,7 @@ const wombatBuild = {
   entry: {
     wombat: "@webrecorder/wombat/src/wbWombat.js",
     wombatWorkers: "@webrecorder/wombat/src/wombatWorkers.js",
-    wombatProxy: "./src/rewrite/proxyinject.ts"
+    wombatProxy: "./src/rewrite/proxyinject.ts",
   },
   output: {
     path: path.join(__dirname, "dist-wombat"),
@@ -46,8 +46,8 @@ const wombatBuild = {
           onlyCompileBundledFiles: false,
         },
       },
-    ]
-  }
+    ],
+  },
 };
 
 const mainBuild = {


### PR DESCRIPTION
Closes #233 

Updates include: 
- [x] Refactored `staticPathProxy` helper that properly passes through body & headers
- [x] Tested & working for Plausible `POST` requests
- [x] Some eslint/TS cleanup

Manual testing:
1. Go to one of the govarchive.us sites (I used https://cdc.govarchive.us/)
2. Open Chrome Devtools (there's likely a way to do this with FF too, I haven't tested)
3. In the **Application** tab, navigate to the **Service Workers** section and click the <kbd>Unregister</kbd> button for the service worker for the site you're on
4. Under the **Source** header, click the **sw.js** link to go to the service worker script in the **Sources** tab
5. Open the sidebar and go to the **Overrides** tab — this may be hidden in the right chevron menu <kbd>»</kbd>
6. Check **Enable Local Overrides**
7. In your terminal, build wabac.js with `yarn build` locally, and copy the contents of `dist/sw.js`
8. Back in the browser, click anywhere in the file contents of `sw.js`, and replace it all with your clipboard contents, and then save (<kbd>Command</kbd>+<kbd>S</kbd> on macOS — it can also be accessed from the **Run command** menu in devtools)
9. Reload the page, and wait for the banner to show up with the page contents
10. Check Plausible stats for the website you're on (e.g. https://p.webrecorder.net/govarchive.us?filters=((is,hostname,(cdc.govarchive.us))))