### PR TITLE
replay: add top frame passthrough when using no replay suffix is set (for pywb support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.22.8",
+  "version": "2.22.9",
   "main": "index.js",
   "type": "module",
   "exports": {


### PR DESCRIPTION
- in this case, assume using a shared path with existing web server
- assume the top-frame is provided by existing web server, just do defaultFetch()
- also pass through any unknown requests (not valid wburl) to existing web server, instead of returning 404
- bump to 2.22.9