### PR TITLE
rewrite: support worker esm module with wkrm_: 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.22.10",
+  "version": "2.22.11",
   "main": "index.js",
   "type": "module",
   "exports": {
@@ -19,7 +19,7 @@
     "@peculiar/asn1-schema": "^2.3.3",
     "@peculiar/x509": "^1.9.2",
     "@types/js-levenshtein": "^1.1.3",
-    "@webrecorder/wombat": "^3.8.8",
+    "@webrecorder/wombat": "^3.8.9",
     "acorn": "^8.10.0",
     "auto-js-ipfs": "^2.1.1",
     "base64-js": "^1.5.1",

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -268,7 +268,11 @@ export class Collection {
       );
     };
 
-    const workerInsertFunc = (text: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const workerInsertFunc = (text: string, opts?: any) => {
+      if (opts?.isModule) {
+        return text;
+      }
       return (
         `
       (function() { self.importScripts('${this.staticPrefix}wombatWorkers.js');\

--- a/src/rewrite/index.ts
+++ b/src/rewrite/index.ts
@@ -45,7 +45,8 @@ export const baseRules = new DomainSpecificRuleSet(RxRewriter);
 // HTML Rx Rewriter (only used externally for now)
 export const htmlRules = new DomainSpecificRuleSet(RxRewriter, HTML_ONLY_RULES);
 
-type InsertFunc = (url: string) => string;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type InsertFunc = (url: string, opts?: any) => string;
 
 type RewriterOpts = {
   baseUrl: string;
@@ -320,6 +321,9 @@ export class Rewriter {
         break;
 
       case "js-worker":
+        if (request.mod === "wkrm_") {
+          opts.isModule = true;
+        }
         rwFunc = this.workerInsertFunc;
         break;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,10 +896,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.2.tgz#ea584b637ff63c5a477f6f21604b5a205b72c9ec"
   integrity sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==
 
-"@webrecorder/wombat@^3.8.8":
-  version "3.8.8"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.8.8.tgz#aab4dd8eea6d6cb17bfefb7ee1802e7b45b11ed7"
-  integrity sha512-XkJOZAyHrdXNkAVoISQEh/NHzaBMekQZfWqes/k2vYkW6v9DmZ0wjP7Kf6MHCuajKX8uSH+caB2tv1kJgvnv3Q==
+"@webrecorder/wombat@^3.8.9":
+  version "3.8.9"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.8.9.tgz#40c9aa0664fee7b257a68a88a92fb9ec17655597"
+  integrity sha512-MzAOCH7ZDkRXfR2ubj2SfwghNMVoL1UnoXXlW/Qdcmy7lO0IPYJbMl4DxzscRIouus/4knWlj0BKZXRFw+PTbw==
   dependencies:
     warcio "^2.4.0"
 


### PR DESCRIPTION
don't prepend rewrite code for esm worker module at all

requires wombat 2.8.9
bump to 2.22.11

(fixes replay of gallery on: https://enfoco.org/nueva-luz-archive/)