### PR TITLE
http-to-https rewriting for proxy replay:

### DIFF
--- a/src/archivedb.ts
+++ b/src/archivedb.ts
@@ -664,6 +664,10 @@ export class ArchiveDB implements DBStore {
       : 0;
     const newOpts = { ...opts, skip };
 
+    if (request.httpToHttpsNeeded) {
+      url = url.slice(url.indexOf("//"));
+    }
+
     if (url.startsWith("//")) {
       let useHttp = false;
       result = await this.lookupUrl("https:" + url, ts, newOpts);

--- a/src/request.ts
+++ b/src/request.ts
@@ -26,6 +26,7 @@ export class ArchiveRequest {
   proxyOrigin?: string;
   proxyScheme = "";
   localOrigin?: string;
+  httpToHttpsNeeded = false;
 
   proxyTLD?: string;
   localTLD?: string;
@@ -96,6 +97,7 @@ export class ArchiveRequest {
         ? new URL(proxyOrigin).protocol.slice(0, -1)
         : "";
       this.localOrigin = localOrigin;
+      this.httpToHttpsNeeded = this.proxyScheme === "http" && localOrigin.startsWith("https:");
       this.proxyTLD = proxyTLD || "";
       this.localTLD = localTLD || "";
     }

--- a/src/rewrite/html.ts
+++ b/src/rewrite/html.ts
@@ -561,6 +561,11 @@ export class ProxyHTMLRewriter extends HTMLRewriter {
       return rewriter.rewriteUrl(text, forceAbs);
     }
 
+    // always rewrite if http->https conversion is needed
+    if ((rewriter as ProxyRewriter).httpToHttps) {
+      return rewriter.rewriteUrl(text, forceAbs);
+    }
+
     return text;
   }
 
@@ -569,6 +574,10 @@ export class ProxyHTMLRewriter extends HTMLRewriter {
     attrRules: Record<string, string>,
     rewriter: Rewriter,
   ) {
+    if ((rewriter as ProxyRewriter).httpToHttps) {
+      return super.rewriteTagAndAttrs(tag, attrRules, rewriter);
+    }
+
     const tagName = tag.tagName;
 
     // no attribute rewriting for web-component tags, which must contain a '-'

--- a/src/rewrite/index.ts
+++ b/src/rewrite/index.ts
@@ -839,6 +839,8 @@ export class ProxyRewriter extends Rewriter {
 
   localScheme: string;
 
+  httpToHttps: boolean;
+
   constructor(opts: RewriterOpts, request: ArchiveRequest) {
     super(opts);
     this.proxyOrigin = request.proxyOrigin!;
@@ -853,6 +855,7 @@ export class ProxyRewriter extends Rewriter {
     const local = new URL(this.localOrigin);
 
     this.localScheme = local.protocol;
+    this.httpToHttps = request.httpToHttpsNeeded;
   }
 
   override rewriteUrl(urlStr: string): string {
@@ -870,6 +873,10 @@ export class ProxyRewriter extends Rewriter {
           this.localScheme + "//" + host + url.href.slice(url.origin.length);
         return newUrl;
       }
+    }
+
+    if (this.httpToHttps) {
+      return urlStr.replace("http:", "https:");
     }
 
     return urlStr;
@@ -910,6 +917,9 @@ export class ProxyRewriter extends Rewriter {
   }
 
   override rewriteCSS(text: string): string {
+    if (this.httpToHttps) {
+      return super.rewriteCSS(text);
+    }
     return text;
   }
 

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1357,7 +1357,7 @@ export class MultiWACZ
       if (inx > 0) {
         pageUrl = request.url.slice(inx);
       }
-    } else if (request.isProxyOrigin && request.referrer) {
+    } else if (request.isProxyOrigin && request.referrer && request.destination !== "document") {
       pageUrl = request.referrer;
       this.referrerMap.set(request.url, pageUrl);
       let topLevelPage: string | undefined = "";


### PR DESCRIPTION
- if proxyOrigin is http, but local origin is https, need to rewrite http->https to avoid security issues
- rewrite http->https in rewriteUrl, as well as script and css as needed so far
- multiwacz: avoid tracking referring for navigation, just page resources