### PR TITLE
Ensure CSP is always set

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -123,7 +123,10 @@ export class Collection {
     this.proxyPrefix = prefixes.proxy;
   }
 
-  async handleRequest(request: ArchiveRequest, event: FetchEvent) {
+  async handleRequest(
+    request: ArchiveRequest,
+    event: FetchEvent,
+  ): Promise<Response> {
     // force timestamp for root coll
     //if (!requestTS && this.isRoot) {
     //requestTS = "2";
@@ -211,6 +214,8 @@ export class Collection {
       return response;
     }
 
+    let noCSPNeeded = false;
+
     if (!response.noRW) {
       if (!request.isProxyOrigin) {
         response = await this.fullRewrite(
@@ -227,6 +232,7 @@ export class Collection {
           baseUrl,
           requestTS,
         );
+        noCSPNeeded = true;
       }
     }
 
@@ -238,7 +244,11 @@ export class Collection {
 
     const deleteDisposition =
       request.destination === "iframe" || request.destination === "document";
-    return response.makeResponse(this.coHeaders, deleteDisposition);
+    return response.makeResponse(
+      this.coHeaders,
+      deleteDisposition,
+      noCSPNeeded,
+    );
   }
 
   async fullRewrite(

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -7,6 +7,7 @@ import {
   parseSetCookie,
   handleAuthNeeded,
   REPLAY_TOP_FRAME_NAME,
+  DEFAULT_CSP,
 } from "./utils";
 
 import { ArchiveResponse } from "./response";
@@ -16,9 +17,6 @@ import { notFoundByTypeResponse } from "./notfound";
 import { type ArchiveDB } from "./archivedb";
 import { type ArchiveRequest } from "./request";
 import { type CollMetadata, type CollConfig, type ExtraConfig } from "./types";
-
-const DEFAULT_CSP =
-  "default-src 'unsafe-eval' 'unsafe-inline' 'self' data: blob: mediastream: ws: wss: ; form-action 'self'";
 
 export type Prefixes = {
   static: string;
@@ -302,9 +300,7 @@ export class Collection {
 
     response = await rewriter.rewrite(response, request);
 
-    if (mod !== "id_") {
-      response.headers.append("Content-Security-Policy", this.csp);
-    }
+    response.headers.set("Content-Security-Policy", this.csp);
 
     return response;
   }

--- a/src/response.ts
+++ b/src/response.ts
@@ -333,7 +333,11 @@ class ArchiveResponse {
     return false;
   }
 
-  makeResponse(coHeaders = false, overwriteDisposition = false) {
+  makeResponse(
+    coHeaders = false,
+    overwriteDisposition = false,
+    noCSPNeeded = false,
+  ) {
     let body: Uint8Array | ReadableStream | null = null;
     if (!isNullBodyStatus(this.status)) {
       body =
@@ -351,6 +355,10 @@ class ArchiveResponse {
     // [TODO]
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (response as any).date = this.date;
+    if (noCSPNeeded) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (response as any).noCSPNeeded = true;
+    }
     if (coHeaders) {
       response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
       response.headers.set("Cross-Origin-Embedder-Policy", "require-corp");

--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -349,9 +349,11 @@ export class SWReplay {
   async handleFetchEnsureCSP(event: FetchEvent): Promise<Response> {
     const response = await this.handleFetch(event);
 
+    // Always add csp header, unless noCSPNeeded has been set
     if (
-      !this.proxyOriginMode &&
-      !response.headers.get("Content-Security-Policy")
+      !response.headers.get("Content-Security-Policy") &&
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      !(response as any).noCSPNeeded
     ) {
       try {
         response.headers.set("Content-Security-Policy", DEFAULT_CSP);
@@ -431,9 +433,9 @@ export class SWReplay {
       (parsedUrl.protocol == "http:" || parsedUrl.protocol == "https:") &&
       parsedUrl.pathname.indexOf("/", 1) < 0
     ) {
-      return this.handleOffline(event.request);
+      return this.handleOffline(request);
     } else {
-      return this.defaultFetch(event.request);
+      return this.defaultFetch(request);
     }
   }
 

--- a/src/swmain.ts
+++ b/src/swmain.ts
@@ -357,7 +357,6 @@ export class SWReplay {
     ) {
       try {
         response.headers.set("Content-Security-Policy", DEFAULT_CSP);
-        return response;
       } catch (_) {
         const headers = new Headers(response.headers);
         const { status, statusText } = response;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,9 @@ export const REPLAY_TOP_FRAME_NAME = "___wb_replay_top_frame";
 
 export const REMOVE_EXPIRES = /Expires=\w{3},\s\d[^;,]+(?:;\s*)?/gi;
 
+export const DEFAULT_CSP =
+  "default-src 'unsafe-eval' 'unsafe-inline' 'self' data: blob: mediastream: ws: wss: ; form-action 'self'";
+
 export function startsWithAny(value: string, iter: Iterable<string>) {
   for (const str of iter) {
     if (value.startsWith(str)) {


### PR DESCRIPTION
- ensure csp policy is always set, even for default fetch / fallthrough responses, unless in proxy origin mode
- if no csp policy is found in handleFetch response, add default csp
- if fail to set csp, make a copy of response