### PR TITLE
Not Found Response / No Collection Redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@peculiar/asn1-schema": "^2.3.3",
     "@peculiar/x509": "^1.9.2",
     "@types/js-levenshtein": "^1.1.3",
-    "@webrecorder/wombat": "^3.8.10",
+    "@webrecorder/wombat": "^3.8.11",
     "acorn": "^8.10.0",
     "auto-js-ipfs": "^2.1.1",
     "base64-js": "^1.5.1",

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -3,7 +3,6 @@ import { ProxyRewriter, Rewriter } from "./rewrite";
 import {
   getTS,
   getSecondsStr,
-  notFound,
   parseSetCookie,
   handleAuthNeeded,
   REPLAY_TOP_FRAME_NAME,
@@ -13,7 +12,7 @@ import {
 import { ArchiveResponse } from "./response";
 
 import { getAdBlockCSSResponse } from "./adblockcss";
-import { notFoundByTypeResponse } from "./notfound";
+import { notFound, notFoundByTypeResponse } from "./notfound";
 import { type ArchiveDB } from "./archivedb";
 import { type ArchiveRequest } from "./request";
 import { type CollMetadata, type CollConfig, type ExtraConfig } from "./types";
@@ -204,7 +203,7 @@ export class Collection {
       }
 
       return notFoundByTypeResponse(
-        request,
+        request.request,
         requestURL,
         requestTS,
         this.liveRedirectOnNotFound,

--- a/src/request.ts
+++ b/src/request.ts
@@ -211,3 +211,15 @@ function resolveProxyOrigin(
   }
   return urlStr;
 }
+
+export function resolveFullUrlFromReferrer(url: string, referrer: string) {
+  const inx = referrer.indexOf("/http");
+  if (inx < 0) {
+    return null;
+  }
+  const origin = new URL(url).origin;
+  const relUrl = url.slice(origin.length);
+  const baseUrl = referrer.slice(inx + 1);
+  const fullUrl = new URL(relUrl, baseUrl);
+  return referrer.slice(0, inx + 1) + fullUrl.href;
+}

--- a/src/rewrite/html.ts
+++ b/src/rewrite/html.ts
@@ -19,7 +19,7 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 // ===========================================================================
-const META_REFRESH_REGEX = /([\d.]+\s*;\s*url\s*=\s*)['"]?(.+)['"]?(\s*)/im;
+const META_REFRESH_REGEX = /([\d.]+\s*;\s*(?:url\s*=)\s*)['"]?(.+)['"]?(\s*)/im;
 
 const DATA_RW_PROTOCOLS = ["http://", "https://", "//"];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -259,36 +259,6 @@ export async function handleAuthNeeded(e: any, config: any) {
   return false;
 }
 
-export function notFound(request: Request, msg?: string, status = 404) {
-  let content;
-  let contentType;
-
-  if (!msg) {
-    msg = "Sorry, this url was not found in the archive.";
-  }
-
-  if (
-    request.destination === "script" ||
-    request.headers.get("x-pywb-requested-with")
-  ) {
-    content = JSON.stringify(msg);
-    contentType = "application/json";
-  } else {
-    content = msg;
-    contentType = "text/html";
-  }
-
-  //console.log(`Not Found ${request.destination} - ${msg}`);
-
-  const initOpt = {
-    status: status,
-    statusText: getStatusText(status),
-    headers: { "Content-Type": contentType },
-  };
-
-  return new Response(content, initOpt);
-}
-
 // [TODO]
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getCollData(coll: any) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,10 +896,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.2.tgz#ea584b637ff63c5a477f6f21604b5a205b72c9ec"
   integrity sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==
 
-"@webrecorder/wombat@^3.8.10":
-  version "3.8.10"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.8.10.tgz#b717d4ce6d01dbdfd38b91f500ebb574c245df93"
-  integrity sha512-BGq05d/7RKRe3H/gtqk/Mag8aQNuPngD3eAWE/81T6FhObldZtCD9UM6q3B0fRaEwEzZ/GLoTT6S6DrUuUxQGw==
+"@webrecorder/wombat@^3.8.11":
+  version "3.8.11"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.8.11.tgz#392a3a7003fdb41f5b214d4571d5f38f9978f2c8"
+  integrity sha512-Sg97woFtMFPh0PJ60WV9sze4nw5aPEq+BE9dFwdd6WpA45da0pkjCVX9z+YXejQLxdvKy24U9+rDPA9W6XqIGQ==
   dependencies:
     warcio "^2.4.0"
 


### PR DESCRIPTION
not-found response cleanup:
- remove old notFound, use type-specific notFound with custom message support
- add csp to not-found response

no-collection redirect:
- catch URL requests that are missing a collection, eg. <current origin>/newPath with referer <current origin>/collection/<ts>mp_/<replay url>/path and redirect to <current origin>/collection/<ts>mp_/<replay url>/newPath
- shouldn't happen if initial rewrite is correct, but will catch these to avoid unnecessary fallthrough

rewrite: fix meta refresh with no url= rewrite

deps: bump wombat to 3.8.11