### PR TITLE
undo more aggressive csp check everywhere as it breaks embeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.22.13",
+  "version": "2.22.14",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -213,8 +213,6 @@ export class Collection {
       return response;
     }
 
-    let noCSPNeeded = false;
-
     if (!response.noRW) {
       if (!request.isProxyOrigin) {
         response = await this.fullRewrite(
@@ -231,7 +229,6 @@ export class Collection {
           baseUrl,
           requestTS,
         );
-        noCSPNeeded = true;
       }
     }
 
@@ -243,11 +240,7 @@ export class Collection {
 
     const deleteDisposition =
       request.destination === "iframe" || request.destination === "document";
-    return response.makeResponse(
-      this.coHeaders,
-      deleteDisposition,
-      noCSPNeeded,
-    );
+    return response.makeResponse(this.coHeaders, deleteDisposition);
   }
 
   async fullRewrite(

--- a/src/response.ts
+++ b/src/response.ts
@@ -333,11 +333,7 @@ class ArchiveResponse {
     return false;
   }
 
-  makeResponse(
-    coHeaders = false,
-    overwriteDisposition = false,
-    noCSPNeeded = false,
-  ) {
+  makeResponse(coHeaders = false, overwriteDisposition = false) {
     let body: Uint8Array | ReadableStream | null = null;
     if (!isNullBodyStatus(this.status)) {
       body =
@@ -355,10 +351,6 @@ class ArchiveResponse {
     // [TODO]
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (response as any).date = this.date;
-    if (noCSPNeeded) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (response as any).noCSPNeeded = true;
-    }
     if (coHeaders) {
       response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
       response.headers.set("Cross-Origin-Embedder-Policy", "require-corp");

--- a/src/rewrite/index.ts
+++ b/src/rewrite/index.ts
@@ -679,6 +679,7 @@ export class Rewriter {
       "proxy-authenticate": "keep",
 
       "public-key-pins": "prefix",
+      "referrer-policy": "prefix",
       "retry-after": "prefix",
       server: "prefix",
 


### PR DESCRIPTION
but keep key hardening in place:
- ensure csp added to all error pages
- ensure 'not found' page served when loading off domain, if referrer is replay
- ensure redirect back to collection for collecton-less replay
- rewrite Referrer-Policy to avoid it being altered
- prefix 'referrer-policy' header to prevent it from being overwritten in replay bump to 2.22.14