### PR TITLE
allow proxy paths + backslash rewriting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.22.16",
+  "version": "2.22.17",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   tsToDate,
   randomId,
   getCollData,
+  addProxyAllowPaths
 } from "./utils";
 
 export { createLoader } from "./blockloaders";

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export {
   tsToDate,
   randomId,
   getCollData,
-  addProxyAllowPaths
+  addProxyAllowPaths,
 } from "./utils";
 
 export { createLoader } from "./blockloaders";

--- a/src/rewrite/index.ts
+++ b/src/rewrite/index.ts
@@ -444,6 +444,9 @@ export class Rewriter {
     const origUrl = url;
 
     url = url.trim();
+    if (url.startsWith("\\")) {
+      url = url.replace(/\\(?![//])/g, "/");
+    }
 
     if (
       !url ||

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -322,4 +322,15 @@ export async function sleep(millis: number) {
   return new Promise((resolve) => setTimeout(resolve, millis));
 }
 
-export const proxyAllowPaths = new Set();
+export const proxyAllowPaths = new Set<string>();
+
+export function addProxyAllowPaths(paths: string[]) {
+  for (const path of paths) {
+    try {
+      const absPath = new URL(path, self.location.href);
+      proxyAllowPaths.add(absPath.href);
+    } catch (_) {
+      // ignore
+    }
+  }
+}

--- a/test/rewriteHTML.ts
+++ b/test/rewriteHTML.ts
@@ -112,6 +112,12 @@ test(
 );
 
 test(
+  rewriteHtml,
+  '<table background="\\path\\img.gif">',
+  '<table background="/prefix/20201226101010mp_/https://example.com/path/img.gif">',
+);
+
+test(
   "A tag with target",
   rewriteHtml,
   '<HTML><A Href="page.html" target="_blank">Text</a></hTmL>',


### PR DESCRIPTION
proxy paths:
- treat proxy allow paths as prefixes:
- add 'allowProxyPrefix' to query params, to allow custom prefixes

backslash:
- rewrite '\' for URLs starting with '\' (and ignore '\/')
- add tests to ensure '\path\file.html' treated same as '/path/file.html'

bump to 2.22.17