### PR TITLE
fix small file loading / range request issues:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.22.17",
+  "version": "2.23.0",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -779,6 +779,12 @@ Make sure this is a valid URL and you have access to this file.`,
           }
           return false;
         }
+
+        // if loader already loaded full buffer, store that
+        const fullBuffer = sourceLoader.getFullBuffer();
+        if (fullBuffer) {
+          config.extra = { arrayBuffer: fullBuffer, ...(config.extra || {}) };
+        }
       } else if (
         stream &&
         (sourceExt === ".warc" || sourceExt === ".warc.gz")


### PR DESCRIPTION
- avoid negative range request if -N is less than full length of file, just load full file instead
- if range requests not supported, but file is small enough (<25MiB, same as full download size), just load entire wacz into memory and do random access from arraybuffer
- blockloaders: add getFullBuffer() to return full buffer, if available, for cacheing
- bump to 2.23.0