### PR TITLE
csp tweak: include SW path (without query) in CSP

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,7 @@ export const DEFAULT_CSP =
 let fullCSP = DEFAULT_CSP;
 
 export function updateCSP(replayPrefix: string) {
-  fullCSP += "; child-src data: about: blob: " + replayPrefix;
+  fullCSP += `; frame-src data: about: blob: ${self.location.origin}${self.location.pathname} ${replayPrefix}`;
 }
 
 export function getCSP() {


### PR DESCRIPTION
Follow-up to #246, Firefox still requires CSP policy for the service worker itself to be allowed to load iframes controlled by the service worker.
Seems like incorrect interpretation of 'frame-src', but need it to fix iframe replay in FF.