### PR TITLE
Optimize loading + periodic delete of expired multiwaczs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.23.0",
+  "version": "2.23.0-beta.1",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.23.0-beta.1",
+  "version": "2.23.0",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/blockloaders.ts
+++ b/src/blockloaders.ts
@@ -295,8 +295,7 @@ class FetchRangeLoader extends BaseLoader {
 
     try {
       resp = await this.retryFetch(this.url, options);
-    } catch (e) {
-      console.log(e);
+    } catch (_) {
       throw new RangeError(this.url);
     }
 

--- a/src/blockloaders.ts
+++ b/src/blockloaders.ts
@@ -245,7 +245,10 @@ class FetchRangeLoader extends BaseLoader {
       this.length > 0 &&
       this.length <= MAX_FULL_DOWNLOAD_SIZE
     ) {
-      const resp = await fetch(this.url);
+      const resp = await this.retryFetch(this.url, {
+        headers,
+        cache: "no-store",
+      });
       if (resp.ok) {
         this.arrayBuffer = new ArrayBufferLoader(
           new Uint8Array(await resp.arrayBuffer()),

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -29,6 +29,7 @@ import {
   randomId,
   AuthNeededError,
   DeleteExpiredError,
+  sleep,
 } from "./utils";
 import { detectFileType, getKnownFileExtension } from "./detectfiletype";
 import {
@@ -116,8 +117,8 @@ export class CollectionLoader {
       const multiWACZs: MultiWACZ[] = [];
 
       // [TODO]
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       const promises = allColls.map(async (data) =>
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         this._initColl(data, multiWACZs),
       );
 
@@ -199,6 +200,8 @@ export class CollectionLoader {
           void this.deleteColl(store.name);
         }
       }
+      // pause for 2 seconds to avoid moving too quickly
+      await sleep(2000);
     }
   }
 
@@ -282,11 +285,10 @@ export class CollectionLoader {
     return coll;
   }
 
-  // [TODO]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async _initColl(
     data: LoadColl,
     storeMultiWACZ: MultiWACZ[] | null = null,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
     const store = await this._initStore(data.type || "", data.config);
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -208,7 +208,7 @@ export class CollectionLoader {
 
     for (const store of stores) {
       const url = store.config.loadUrl || store.config.sourceUrl;
-      if (!url.startsWith("https:") || !url.startsWith("http:")) {
+      if (!url.startsWith("https://") && !url.startsWith("http://")) {
         continue;
       }
       try {

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -207,13 +207,15 @@ export class CollectionLoader {
     }
 
     for (const store of stores) {
+      const url = store.config.loadUrl || store.config.sourceUrl;
+      if (!url.startsWith("https:") || !url.startsWith("http:")) {
+        continue;
+      }
       try {
         await store.checkUpdates();
       } catch (e) {
         if (e instanceof DeleteExpiredError) {
-          console.warn(
-            "Deleting expired/invalid coll for " + store.config.loadUrl,
-          );
+          console.warn("Deleting expired/invalid coll for " + url);
           void this.deleteColl(store.name);
         }
       }

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -113,11 +113,13 @@ export class CollectionLoader {
     try {
       const allColls = await this.listAll();
 
-      const multiWACZs : MultiWACZ[] = [];
+      const multiWACZs: MultiWACZ[] = [];
 
       // [TODO]
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      const promises = allColls.map(async (data) => this._initColl(data, multiWACZs));
+      const promises = allColls.map(async (data) =>
+        this._initColl(data, multiWACZs),
+      );
 
       await Promise.all(promises);
 
@@ -191,7 +193,9 @@ export class CollectionLoader {
         await store.checkUpdates();
       } catch (e) {
         if (e instanceof DeleteExpiredError) {
-          console.warn("Deleting expired/invalid coll for " + store.config.loadUrl);
+          console.warn(
+            "Deleting expired/invalid coll for " + store.config.loadUrl,
+          );
           void this.deleteColl(store.name);
         }
       }
@@ -280,7 +284,10 @@ export class CollectionLoader {
 
   // [TODO]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private async _initColl(data: LoadColl, storeMultiWACZ : MultiWACZ[] | null = null): Promise<any> {
+  private async _initColl(
+    data: LoadColl,
+    storeMultiWACZ: MultiWACZ[] | null = null,
+  ): Promise<any> {
     const store = await this._initStore(data.type || "", data.config);
 
     const name = data.name;

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -28,6 +28,7 @@ import {
   MAX_FULL_DOWNLOAD_SIZE,
   randomId,
   AuthNeededError,
+  DeleteExpiredError,
 } from "./utils";
 import { detectFileType, getKnownFileExtension } from "./detectfiletype";
 import {
@@ -261,7 +262,15 @@ export class CollectionLoader {
   // [TODO]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async _initColl(data: LoadColl): Promise<any> {
-    const store = await this._initStore(data.type || "", data.config);
+    let store = null;
+    try {
+     store = await this._initStore(data.type || "", data.config);
+    } catch (e) {
+      if (e instanceof DeleteExpiredError) {
+        void this.deleteColl(data.name).finally(() => console.log("Delete expired coll: " + data.name));
+        return null;
+      }
+    }
 
     const name = data.name;
     const config = data.config;

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,14 +188,43 @@ export type CollConfig = {
   onDemand?: boolean;
 };
 
+export type PreloadResources = {
+  name: string;
+  crawlId: string;
+};
+
+export type WACZPageEntry = {
+  id: string;
+  url: string;
+  title?: string;
+  ts: number;
+  mime: string;
+  status: number;
+  depth: number;
+  favIconUrl?: string;
+  filename: string;
+  isSeed: boolean;
+  crawl_id?: string;
+};
+
+export type MultiWACZJsonSpec = {
+  resources: { name: string; path: string; hash: string; crawlId?: string }[];
+  profile: string;
+  initialPages?: WACZPageEntry[];
+  preloadResources?: PreloadResources[];
+  totalPages?: number;
+  pagesQueryUrl?: string;
+};
+
 export type WACZCollConfig = CollConfig & {
   dbname: string;
   noCache?: boolean;
   decode?: unknown;
   loadUrl: string;
-  metadata?: CollMetadata & {
-    textIndex?: string;
-  };
+  metadata?: CollMetadata &
+    Partial<MultiWACZJsonSpec> & {
+      textIndex?: string;
+    };
   extraConfig?: ExtraConfig & {
     decodeResponses?: unknown;
     hostProxy?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -318,6 +318,8 @@ export class AccessDeniedError extends RangeError {}
 
 export class Canceled {}
 
+export class DeleteExpiredError {}
+
 export async function sleep(millis: number) {
   return new Promise((resolve) => setTimeout(resolve, millis));
 }

--- a/src/wacz/certutils.ts
+++ b/src/wacz/certutils.ts
@@ -5,11 +5,11 @@ import {
 import { base16 } from "../utils";
 
 import * as x509 from "@peculiar/x509";
-import { AsnParser } from "@peculiar/asn1-schema";
-import { ECDSASigValue } from "@peculiar/asn1-ecc";
+// import { AsnParser } from "@peculiar/asn1-schema";
+// import { ECDSASigValue } from "@peculiar/asn1-ecc";
 //import { ASN1 } from "asn1-parser";
 
-import { concatChunks } from "warcio";
+//import { concatChunks } from "warcio";
 
 const SPLIT_PEM = /-{5}(BEGIN|END) .*-{5}/gm;
 
@@ -134,25 +134,23 @@ export async function verifyWACZSignature({
   return results;
 }
 
-// [TODO]
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function parseASN1Signature(signature: Uint8Array) {
-  // extract r|s values from asn1
-  try {
-    const sig = AsnParser.parse(signature, ECDSASigValue);
+// function parseASN1Signature(signature: Uint8Array) {
+//   // extract r|s values from asn1
+//   try {
+//     const sig = AsnParser.parse(signature, ECDSASigValue);
 
-    const sigR = sig.r as Uint8Array;
-    const sigS = sig.s as Uint8Array;
+//     const sigR = sig.r as Uint8Array;
+//     const sigS = sig.s as Uint8Array;
 
-    const r = sigR[0] === 0 ? sigR.slice(1) : sigR;
-    const s = sigS[0] === 0 ? sigS.slice(1) : sigS;
-    signature = concatChunks([r, s], r.length + s.length);
-  } catch (se) {
-    console.log(se);
-  }
+//     const r = sigR[0] === 0 ? sigR.slice(1) : sigR;
+//     const s = sigS[0] === 0 ? sigS.slice(1) : sigS;
+//     signature = concatChunks([r, s], r.length + s.length);
+//   } catch (se) {
+//     console.log(se);
+//   }
 
-  return signature;
-}
+//   return signature;
+// }
 
 // function parseSignature2(signature) {
 //   // extract r|s values from asn1

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -12,6 +12,7 @@ import {
   getTS,
   sleep,
   DeleteExpiredError,
+  RangeError,
 } from "../utils";
 import { type AsyncIterReader, getSurt } from "warcio";
 import { LiveProxy } from "../liveproxy";
@@ -48,7 +49,7 @@ import {
 
 const MAX_BLOCKS = 3;
 
-const MAX_JSON_LOAD_RETRIES = 5;
+const MAX_JSON_LOAD_RETRIES = 3;
 
 const IS_SURT = /^([\w-]+,)*[\w-]+(:\d+)?,?\)\//;
 
@@ -1286,7 +1287,7 @@ export class MultiWACZ
       return false;
     }
 
-    if (e instanceof AccessDeniedError) {
+    if (e instanceof AccessDeniedError || e instanceof RangeError) {
       try {
         if (!this.updating) {
           this.updating = this.checkUpdates();

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1524,7 +1524,10 @@ export class MultiWACZ
     // [TODO]
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!response || (response.status !== 206 && response.status !== 200)) {
-      console.warn("WACZ update failed from: " + this.config.loadUrl);
+      console.warn(
+        "WACZ update failed from: " +
+          (this.config.loadUrl || this.config.sourceUrl),
+      );
       throw new AccessDeniedError();
     }
 

--- a/src/wacz/waczloader.ts
+++ b/src/wacz/waczloader.ts
@@ -162,8 +162,12 @@ export class JSONResponseMultiWACZLoader implements ArchiveLoader {
   // [TODO]
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async load(db: any) {
-    // [TODO]
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return await db.loadFromJSON(this.response);
+    try {
+      // [TODO]
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return await db.loadFromJSON(this.response);
+    } catch (_) {
+      return {};
+    }
   }
 }


### PR DESCRIPTION
- Don't reload every multiWACZ collection JSON source on service worker init
- Load known multiwacz settings from metadata instead
- Do an async background check of multiWACZ collections, no more than one per day, and prune when JSON file can no longer be accessed.
- Catch fetch errors that are due to CORS and treat same as access denied, allow multiple retries for loading WACZs in case of etch errors
- Add typing for multiWACZ JSON 