### PR TITLE
rewrite: adjust meta refresh to make 'url=' optional

### DIFF
--- a/src/rewrite/html.ts
+++ b/src/rewrite/html.ts
@@ -19,7 +19,8 @@ const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 // ===========================================================================
-const META_REFRESH_REGEX = /([\d.]+\s*;\s*(?:url\s*=)\s*)['"]?(.+)['"]?(\s*)/im;
+const META_REFRESH_REGEX =
+  /([\d.]+\s*;\s*(?:url\s*=)?\s*)['"]?(.+)['"]?(\s*)/im;
 
 const DATA_RW_PROTOCOLS = ["http://", "https://", "//"];
 

--- a/test/rewriteHTML.ts
+++ b/test/rewriteHTML.ts
@@ -285,6 +285,13 @@ test(
 );
 
 test(
+  "<meta> tag, no URL=",
+  rewriteHtml,
+  '<meta http-equiv="refresh" content="10;   /abc/def.html">',
+  '<meta http-equiv="refresh" content="10;   /prefix/20201226101010mp_/https://example.com/abc/def.html">',
+);
+
+test(
   "<meta> tag",
   rewriteHtml,
   '<meta http-equiv="Content-type" content="text/html; charset=utf-8" />',


### PR DESCRIPTION
ensure rewriting even when 'URL=' is missing in meta refresh