### PR TITLE
typing: add typing for extraOpts included in WARC-JSON-Metadata

### DIFF
--- a/src/baseparser.ts
+++ b/src/baseparser.ts
@@ -3,6 +3,7 @@ import {
   type ArchiveLoader,
   type DBStore,
   type PageEntry,
+  type ExtraOpts,
 } from "./types";
 
 const DEFAULT_BATCH_SIZE = 1000;
@@ -21,9 +22,7 @@ export type ResourceEntry = {
   payload?: Uint8Array | null;
   reader?: AsyncIterable<Uint8Array> | Iterable<Uint8Array> | null;
   referrer?: string | null;
-  // [TODO]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  extraOpts?: Record<string, any> | null;
+  extraOpts?: ExtraOpts | null;
   pageId?: string | null;
   origURL?: string | null;
   origTS?: number | null;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -334,6 +334,10 @@ export class Collection {
 
       const seconds = getSecondsStr(response.date);
 
+      const extraOpts = response.extraOpts;
+
+      const disableMSE = extraOpts?.disableMSE;
+
       return `
 <!-- WB Insert -->
 <script>
@@ -357,6 +361,7 @@ ${
 <script src="${this.proxyPrefix}${this.proxyBannerUrl}"></script>`
     : ``
 }
+${disableMSE ? DISABLE_MEDIASOURCE_SCRIPT : ""}
 <!-- End WB Insert -->
     `;
     };
@@ -635,16 +640,12 @@ window.home = "${this.rootPrefix}";
     const presetCookieStr = this.getCookiePreset(response, scheme);
 
     const pixelRatio =
-      // @ts-expect-error [TODO] - TS4111 - Property 'pixelRatio' comes from an index signature, so it must be accessed with ['pixelRatio']. | TS4111 - Property 'pixelRatio' comes from an index signature, so it must be accessed with ['pixelRatio'].
       extraOpts && Number(extraOpts.pixelRatio) ? extraOpts.pixelRatio : 2;
-    // @ts-expect-error [TODO] - TS4111 - Property 'storage' comes from an index signature, so it must be accessed with ['storage']. | TS4111 - Property 'storage' comes from an index signature, so it must be accessed with ['storage'].
 
     const storage = extraOpts?.storage
-      ? // @ts-expect-error [TODO] - TS4111 - Property 'storage' comes from an index signature, so it must be accessed with ['storage']. | TS4111 - Property 'storage' comes from an index signature, so it must be accessed with ['storage'].
-        JSON.stringify(extraOpts.storage)
+      ? JSON.stringify(extraOpts.storage)
       : '""';
 
-    // @ts-expect-error [TODO] - TS4111 - Property 'storage' comes from an index signature, so it must be accessed with ['storage']. | TS4111 - Property 'storage' comes from an index signature, so it must be accessed with ['storage'].
     const disableMSE = extraOpts?.disableMSE;
 
     return `

--- a/src/response.ts
+++ b/src/response.ts
@@ -9,6 +9,7 @@ import {
   INITIAL_STREAM_CHUNK_SIZE,
 } from "./utils";
 import { Buffer } from "buffer";
+import { type ExtraOpts } from "./types";
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -20,9 +21,7 @@ type ArchiveResponseOpts = {
   headers: Headers;
   url: string;
   date: Date;
-  // [TODO]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  extraOpts?: Record<string, any> | null;
+  extraOpts?: ExtraOpts | null;
   noRW?: boolean;
   isLive?: boolean;
   updateTS?: string | null;
@@ -128,9 +127,7 @@ class ArchiveResponse {
   statusText: string;
   url: string;
   date: Date;
-  // [TODO]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  extraOpts: Record<string, any> | null;
+  extraOpts: ExtraOpts | null;
   headers: Headers;
   noRW: boolean;
   isLive: boolean;

--- a/src/rewrite/dsruleset.ts
+++ b/src/rewrite/dsruleset.ts
@@ -1,3 +1,4 @@
+import { type ArchiveResponse } from "../response";
 import { rewriteDASH } from "./rewriteVideo";
 import { type RxRewriter, type Rule } from "./rxrewriter";
 
@@ -215,7 +216,8 @@ function ruleDisableMediaSourceTypeSupported() {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setMaxBitrate(opts: any) {
   let maxBitrate = MAX_BITRATE;
-  const extraOpts = opts.response?.extraOpts;
+  const response = opts.response as ArchiveResponse | null;
+  const extraOpts = response?.extraOpts;
 
   if (opts.save) {
     opts.save.maxBitrate = maxBitrate;

--- a/src/rewrite/rewriteVideo.ts
+++ b/src/rewrite/rewriteVideo.ts
@@ -1,4 +1,5 @@
 import { XMLParser, XMLBuilder } from "fast-xml-parser";
+import { type ArchiveResponse } from "../response";
 
 // orig pywb defaults
 const OLD_DEFAULT_MAX_BAND = 2000000;
@@ -16,7 +17,8 @@ function getMaxResAndBand(opts: Record<string, any> = {}) {
   let maxRes, maxBand;
 
   // @ts-expect-error [TODO] - TS4111 - Property 'response' comes from an index signature, so it must be accessed with ['response'].
-  const extraOpts = opts.response?.extraOpts;
+  const response = opts.response as ArchiveResponse | null;
+  const extraOpts = response?.extraOpts;
 
   if (extraOpts) {
     maxRes = extraOpts.adaptive_max_resolution || extraOpts.maxRes;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,37 @@ export type Source = {
   wacz?: string;
 };
 
+// known options that can be included in WARC header as WARC-JSON-Metadata: <extraOpts json>
+export type ExtraOpts = {
+  // Video options
+  maxBitrate?: number;
+  adaptive_max_resolution?: number;
+  maxRes?: number;
+  adaptive_max_bandwidth?: number;
+  maxBand?: number;
+
+  // Pixel Ratio
+  pixelRatio?: number;
+
+  // Local/Session Storage
+  storage?: string;
+
+  // IP Info
+  ipType?: string;
+
+  // Cert Info
+  cert?: {
+    issuer: string;
+    ctc: string;
+  }
+
+  // if content was rewritten
+  rewritten?: number;
+
+  // if disabling media source extensions
+  disableMSE?: number;
+};
+
 export type ResourceEntry = {
   url: string;
   ts: number;
@@ -24,9 +55,7 @@ export type ResourceEntry = {
   payload?: Uint8Array | null;
   reader?: BaseAsyncIterReader | null;
   referrer?: string | null;
-  // [TODO]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  extraOpts?: Record<string, any> | null;
+  extraOpts?: ExtraOpts | null;
   pageId?: string | null;
   origURL?: string | null;
   origTS?: number | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export type ExtraOpts = {
   cert?: {
     issuer: string;
     ctc: string;
-  }
+  };
 
   // if content was rewritten
   rewritten?: number;


### PR DESCRIPTION
- add ExtraOpts type covering known types used in AWP and browsertrix-crawler
- add disableMSE check to proxy mode replay