### PR TITLE
csp fix for root collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.23.5",
+  "version": "2.23.6",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -93,8 +93,6 @@ export class Collection {
 
     this.coHeaders = extraConfig.coHeaders || false;
 
-    this.csp = extraConfig.csp || getCSP() + this.name + "/";
-
     this.injectRelCanon = extraConfig.injectRelCanon || false;
 
     this.baseFramePrefix = extraConfig.baseUrlSourcePrefix!;
@@ -118,9 +116,11 @@ export class Collection {
     // support root collection hashtag nav
     if (this.config.root) {
       this.isRoot = true;
+      this.csp = extraConfig.csp || getCSP();
     } else {
       this.prefix += this.name + "/";
       this.isRoot = false;
+      this.csp = extraConfig.csp || getCSP() + this.name + "/";
     }
 
     this.staticPrefix = prefixes.static;

--- a/src/rewrite/proxyinject.ts
+++ b/src/rewrite/proxyinject.ts
@@ -530,7 +530,8 @@ class ProxyWombatRewrite {
   }
 
   overrideSWAccess() {
-    const _WB_wombat_sw = window.navigator.serviceWorker;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (self as any).__WB_wombat_sw = window.navigator.serviceWorker;
 
     const overrideSW = {
       controller: null,


### PR DESCRIPTION
- fix csp for root collection, don't include collection prefix in CSP
- proxy rewrite: save original sw just in case
- bump to 2.23.6