### PR TITLE
JS rewrite fixes: top-level globals + location rewrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.23.6",
+  "version": "2.23.7",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/rewrite/jsrewriter.ts
+++ b/src/rewrite/jsrewriter.ts
@@ -150,7 +150,7 @@ const createJSRules: () => Rule[] = () => {
 
     // rewriting 'location = ' to custom expression '(...).href =' assignment
     [
-      /(?:^|[^$.+*/%^-])\s?\blocation\b\s*[=]\s*(?![\s\d=])/,
+      /(?:^|[^$.+*/%^-])\s?\blocation\b\s*[=]\s*(?![\s\d=>])/,
       addSuffix(checkLoc),
     ],
 
@@ -268,6 +268,12 @@ if (!self.__WB_pmw) { self.__WB_pmw = function(obj) { this.__WB_source = obj; re
               names.push(`self.${name} = ${name};`);
             }
           }
+        }
+        // Check for class declarations
+      } else if (type === "ClassDeclaration") {
+        if (expr.id && expr.id.type === "Identifier" && expr.id.name) {
+          const name = expr.id.name;
+          names.push(`self.${name} = ${name};`);
         }
         // Check for document.write() calls
       } else if (!hasDocWrite && type === "ExpressionStatement") {

--- a/src/rewrite/jsrewriter.ts
+++ b/src/rewrite/jsrewriter.ts
@@ -308,7 +308,7 @@ if (!self.__WB_pmw) { self.__WB_pmw = function(obj) { this.__WB_source = obj; re
     }
 
     if (names.length) {
-      return "\n" + names.join("\n");
+      return "\n;" + names.join("\n");
     } else {
       return "";
     }

--- a/test/rewriteJS.ts
+++ b/test/rewriteJS.ts
@@ -178,10 +178,7 @@ test(
   "location = ((self.__WB_check_loc && self.__WB_check_loc(location, arguments)) || {}).href = http://example.com/",
 );
 
-test(
-  rewriteJSWrapped,
-  "location => \"http://example.com/\"",
-);
+test(rewriteJSWrapped, 'location => "http://example.com/"');
 
 // acorn fails here, but is ignorable
 test(
@@ -211,8 +208,6 @@ test(
 self.B = B;
 self.C = C;`,
 );
-
-
 
 test(
   rewriteJS,

--- a/test/rewriteJS.ts
+++ b/test/rewriteJS.ts
@@ -178,12 +178,41 @@ test(
   "location = ((self.__WB_check_loc && self.__WB_check_loc(location, arguments)) || {}).href = http://example.com/",
 );
 
+test(
+  rewriteJSWrapped,
+  "location => \"http://example.com/\"",
+);
+
 // acorn fails here, but is ignorable
 test(
   rewriteJSWrapped,
   " location = http://example.com/2",
   " location = ((self.__WB_check_loc && self.__WB_check_loc(location, arguments)) || {}).href = http://example.com/2",
 );
+
+test(
+  rewriteJSWrapped,
+  `
+  class A {}
+  const B = 5;
+  let C = 4;
+  var D = 3;
+
+  location = "http://example.com/2"`,
+
+  `
+  class A {}
+  const B = 5;
+  let C = 4;
+  var D = 3;
+
+  location = ((self.__WB_check_loc && self.__WB_check_loc(location, arguments)) || {}).href = "http://example.com/2"
+;self.A = A;
+self.B = B;
+self.C = C;`,
+);
+
+
 
 test(
   rewriteJS,
@@ -222,8 +251,8 @@ test(
 // add global injection
 test(
   rewriteJSWrapped,
-  "let a = document.location.href; var b = 5; const foo = 4;",
-  "let a = document.location.href; var b = 5; const foo = 4;\nself.a = a;\nself.foo = foo;",
+  "let a = document.location.href; var b = 5; const foo = 4",
+  "let a = document.location.href; var b = 5; const foo = 4\n;self.a = a;\nself.foo = foo;",
 );
 
 // import rewrite


### PR DESCRIPTION
- js: add global 'class NAME' as 'self.NAME = NAME' in non-esm scripts, follow-up to #128, support for top-level globals
- js: don't rewrite 'location => ' construction, add check for '>' after '='

bump to 2.23.7