### PR TITLE
esm rewriting fix:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.23.8",
+  "version": "2.23.9",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/rewrite/jsrewriter.ts
+++ b/src/rewrite/jsrewriter.ts
@@ -4,11 +4,11 @@ import * as acorn from "acorn";
 const IMPORT_RX = /^\s*?import\s*?[{"'*]/;
 const EXPORT_RX = /^\s*?export\s*?({([\s\w,$\n]+?)}[\s;]*|default|class)\s+/m;
 
-const IMPORT_MATCH_RX =
-  /^\s*?import(?:['"\s]*(?:[\w*${}\s,]+from\s*)?['"\s]?['"\s])(?:.*?)['"\s]/;
+const IMPORT_EXPORT_MATCH_RX =
+  /(^|;)\s*?(?:im|ex)port(?:['"\s]*(?:[\w*${}\s,]+from\s*)?['"\s]?['"\s])(?:.*?)['"\s]/;
 
-const IMPORT_HTTP_RX =
-  /(import(?:['"\s]*(?:[\w*${}\s,]+from\s*)?['"\s]?['"\s]))((?:https?|[./]).*?)(['"\s])/;
+const IMPORT_EXPORT_HTTP_RX =
+  /((?:im|ex)port(?:['"\s]*(?:[\w*${}\s,]+from\s*)?['"\s]?['"\s]))((?:https?|[./]).*?)(['"\s])/;
 
 const GLOBAL_OVERRIDES = [
   "window",
@@ -391,7 +391,7 @@ if (!self.__WB_pmw) { self.__WB_pmw = function(obj) { this.__WB_source = obj; re
         // @ts-expect-error [TODO] - TS4111 - Property 'prefix' comes from an index signature, so it must be accessed with ['prefix'].
         const prefix = opts.prefix.replace("mp_/", "esm_/");
 
-        return x.replace(IMPORT_HTTP_RX, (_, g1, g2, g3) => {
+        return x.replace(IMPORT_EXPORT_HTTP_RX, (_, g1, g2, g3) => {
           try {
             // @ts-expect-error [TODO] - TS4111 - Property 'baseUrl' comes from an index signature, so it must be accessed with ['baseUrl'].
             // [TODO]
@@ -411,7 +411,7 @@ if (!self.__WB_pmw) { self.__WB_pmw = function(obj) { this.__WB_source = obj; re
     }
 
     // match and rewrite import statements
-    return [IMPORT_MATCH_RX, rewriteImport()];
+    return [IMPORT_EXPORT_MATCH_RX, rewriteImport()];
   }
 }
 

--- a/test/rewriteJS.ts
+++ b/test/rewriteJS.ts
@@ -307,6 +307,28 @@ export { a };
 `,
 );
 
+// rewrite import same line
+test(
+  rewriteJSImport,
+  `\
+import{A, B} from "https://example.com/";import{C, D} from "https://example.org"
+`,
+  `\
+import{A, B} from "http://localhost:8080/prefix/20201226101010esm_/https://example.com/";import{C, D} from "http://localhost:8080/prefix/20201226101010esm_/https://example.org/"
+`,
+);
+
+// rewrite import/export same line
+test(
+  rewriteJSImport,
+  `\
+import{A, B} from "https://example.com/";export{C, D} from "/some/path/to/file"
+`,
+  `\
+import{A, B} from "http://localhost:8080/prefix/20201226101010esm_/https://example.com/";export{C, D} from "http://localhost:8080/prefix/20201226101010esm_/https://example.com/some/path/to/file"
+`,
+);
+
 // rewrite ESM module import
 test(
   rewriteJSImport,


### PR DESCRIPTION
- match multiple 'import' per line (separated by ';')
- can rewrite 'export' per line as well
- tests: add tests for multiple import/export rewriting
- fixes issues in #269
- bump to 2.23.9