### PR TITLE
rewrite: fix eval() rewriting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.23.9",
+  "version": "2.23.10",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/rewrite/jsrewriter.ts
+++ b/src/rewrite/jsrewriter.ts
@@ -136,7 +136,10 @@ const createJSRules: () => Rule[] = () => {
 
   return [
     // rewriting 'eval(...)' - invocation
-    [/(?:^|\s)\beval\s*\(/, replacePrefixFrom(evalStr, "eval")],
+    [
+      /(?<!static|function|})(?:^|\s)\beval\s*\(/,
+      replacePrefixFrom(evalStr, "eval"),
+    ],
 
     [/\([\w]+,\s*eval\)\(/, () => " " + evalStr],
 

--- a/test/rewriteJS.ts
+++ b/test/rewriteJS.ts
@@ -407,6 +407,10 @@ test(rewriteJS, "this.$eval(a)", "");
 
 test(rewriteJS, "x = $eval; x(a);", "");
 
+test(rewriteJS, "static eval(a,b){ }", "");
+test(rewriteJS, "function eval(a,b){ }", "");
+test(rewriteJS, "} eval(a,b){ }", "");
+
 test(rewriteJSWrapped, "window.eval(a)", "");
 
 test(rewriteJSWrapped, "x = window.eval; x(a);", "");


### PR DESCRIPTION
- additional rewrite fixes with negative lookbehind (now supported in all browsers)
- fixes replay where 'static eval' as well as 'function eval' and '} eval' are skipped