### PR TITLE
module workers rewriting improvements:

### DIFF
--- a/.github/workflows/make-draft-release.yaml
+++ b/.github/workflows/make-draft-release.yaml
@@ -19,8 +19,12 @@ jobs:
           echo "version=$(jq -r .version package.json)" >> "$GITHUB_ENV"
 
       - name: Make Draft Release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          name: "wabac.js v${{ env.version }}"
-          tag_name: v${{ env.version }}
+          allowUpdates: true
           draft: true
+          generateReleaseNotes: true
+          name: wombat ${{ env.version }}
+          skipIfReleaseExists: true
+          tag: v${{ env.version }}
+          updateOnlyUnreleased: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.23.11",
+  "version": "2.24.0",
   "main": "index.js",
   "type": "module",
   "exports": {
@@ -19,7 +19,7 @@
     "@peculiar/asn1-schema": "^2.3.3",
     "@peculiar/x509": "^1.9.2",
     "@types/js-levenshtein": "^1.1.3",
-    "@webrecorder/wombat": "^3.8.14",
+    "@webrecorder/wombat": "^3.9.0",
     "acorn": "^8.10.0",
     "auto-js-ipfs": "^2.1.1",
     "base64-js": "^1.5.1",

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -273,17 +273,20 @@ export class Collection {
       );
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const workerInsertFunc = (text: string, opts?: any) => {
-      if (opts?.isModule) {
-        return text;
+    const workerInsertFunc = (isModule: boolean) => {
+      const newWBWombat = `new WBWombat(
+        {"prefix": "${basePrefixTS}",
+         "mod": "wkr_",
+         "originalURL": "${requestURL}"
+        })`;
+
+      if (isModule) {
+        return `import '${this.staticPrefix}wombatWorkers.js'; if (!self.__wb_wombat) { self.__wb_wombat = ${newWBWombat} }`;
       }
-      return (
-        `
-      (function() { self.importScripts('${this.staticPrefix}wombatWorkers.js');\
-          new WBWombat({'prefix': '${basePrefixTS}/', 'prefixMod': '${basePrefixTS}wkrf_/', 'originalURL': '${requestURL}'});\
-      })();` + text
-      );
+      return `
+      { if (!self.__wb_wombat) { self.importScripts('${this.staticPrefix}wombatWorkers.js'); \
+        self.__wb_wombat = ${newWBWombat};}\
+      }`;
     };
 
     const mod = TO_MP.includes(request.mod) ? "mp_" : request.mod;

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,10 +889,10 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.5.2.tgz#ea584b637ff63c5a477f6f21604b5a205b72c9ec"
   integrity sha512-vgJ5OLWadI8aKjDlOH3rb+dYyPd2GTZuQC/Tihjct6F9GpXGZINo3Y/IVuZVTM1eDQB+/AOsjPUWH/WySDaXvw==
 
-"@webrecorder/wombat@^3.8.14":
-  version "3.8.14"
-  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.8.14.tgz#fde951519ed9ab8271107a013fc1abd6a9997424"
-  integrity sha512-1CaL8Oel02V321SS+wOomV+cSDo279eVEAuiamO9jl9YoijRsGL9z/xZKE6sz6npLltE3YYziEBYO81xnaeTcA==
+"@webrecorder/wombat@^3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@webrecorder/wombat/-/wombat-3.9.0.tgz#a10116d01e1df66df791dc79c4ad58ee07de9308"
+  integrity sha512-o6ahV9DIi4/DkD13Qh4oGK0P+ZLn9ruu5sAUdqe51UXEdDsQNVuGbtf++bsOoKkLlsjL5QJZny2CEiJesLlsnw==
   dependencies:
     warcio "^2.4.0"
 


### PR DESCRIPTION
- support module workers with wkrm_ modifier, module-specific worker rewriting (eg. use import instead of importScripts)
- support hoisting globals + 'location' override if location is used in a worker
- bump wombat to 3.9.0 to support module workers + additional worker rewriting support
- fixes #274
- ci: update script to automatically make draft release for new version