### PR TITLE
liveproxy: only check for redirect if response.url is set and response.ok is true

### DIFF
--- a/src/liveproxy.ts
+++ b/src/liveproxy.ts
@@ -169,7 +169,7 @@ export class LiveProxy implements DBStore {
       // was a redirect, issue a redirect to the exact URL
       const fullFetchURL = new URL(fetchUrl, self.location.href).href;
 
-      if (response.url !== fullFetchURL) {
+      if (response.ok && response.url && response.url !== fullFetchURL) {
         const inx = response.url.indexOf("/http");
         const actualUrl = response.url.slice(inx + 1);
         // ensure actual URL is different, not just timestamp


### PR DESCRIPTION
otherwise, end up redirecting to empty url (which ends up being the sw url).