### PR TITLE
optimization: limit POST append URL length + use acorn-loose for globals parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "main": "index.js",
   "type": "module",
   "exports": {
@@ -20,7 +20,7 @@
     "@peculiar/x509": "^1.9.2",
     "@types/js-levenshtein": "^1.1.3",
     "@webrecorder/wombat": "^3.9.1",
-    "acorn": "^8.10.0",
+    "acorn-loose": "^8.5.2",
     "auto-js-ipfs": "^2.1.1",
     "base64-js": "^1.5.1",
     "brotli": "^1.3.3",

--- a/src/fuzzymatcher.ts
+++ b/src/fuzzymatcher.ts
@@ -35,7 +35,7 @@ function joinRx(rxStr: string[]) {
   );
 }
 
-const MAX_ARG_LEN = 1024;
+export const MAX_ARG_LEN = 1024;
 
 const SPLIT_BASE_RX = /\[\d]+/;
 

--- a/src/rewrite/jsrewriter.ts
+++ b/src/rewrite/jsrewriter.ts
@@ -1,5 +1,5 @@
 import { type Rule, RxRewriter } from "./rxrewriter";
-import * as acorn from "acorn";
+import * as acorn from "acorn-loose";
 
 const IMPORT_RX = /^\s*?import\s*?[{"'*]/;
 const EXPORT_RX = /^\s*?export\s*?({([\s\w,$\n]+?)}[\s;]*|default|class)\s+/m;

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,6 +939,13 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-loose@^8.5.2:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/acorn-loose/-/acorn-loose-8.5.2.tgz#a7cc7dfbb7c8f3c2e55b055db640dc657e278d26"
+  integrity sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==
+  dependencies:
+    acorn "^8.15.0"
+
 acorn-walk@^8.3.2:
   version "8.3.3"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.3.tgz#9caeac29eefaa0c41e3d4c65137de4d6f34df43e"
@@ -946,10 +953,20 @@ acorn-walk@^8.3.2:
   dependencies:
     acorn "^8.11.0"
 
-acorn@^8.10.0, acorn@^8.11.0, acorn@^8.11.3, acorn@^8.15.0, acorn@^8.6.0, acorn@^8.7.1, acorn@^8.9.0:
+acorn@^8.11.0, acorn@^8.11.3, acorn@^8.6.0, acorn@^8.9.0:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
+  integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
+
+acorn@^8.15.0:
   version "8.15.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
+
+acorn@^8.7.1:
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.9.0.tgz#78a16e3b2bcc198c10822786fa6679e245db5b59"
+  integrity sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==
 
 agent-base@6:
   version "6.0.2"


### PR DESCRIPTION
- limit size of URLS with POST appended to either 8192 for json/js/html (fixed list of mimes) or 512 (all other, probably ignoring POST anyway)
- js parsing: use acorn-loose parse for more lax parsing as we just need the globals

bump to 2.24.3