### PR TITLE
additional per-collection options for homepage override and exclusions:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -61,11 +61,15 @@ export class Collection {
 
   adblockUrl?: string;
 
+  excludeUrlPaths?: string[];
+
   staticPrefix: string;
   proxyPrefix: string;
 
   proxyBannerUrl = "";
   proxyCustomInsert = "";
+
+  proxyHomePageUrl?: string;
 
   constructor(
     // [TODO]
@@ -106,7 +110,11 @@ export class Collection {
 
     this.rootPrefix = prefixes.root || prefixes.main;
 
+    this.proxyHomePageUrl = extraConfig.proxyHomePageUrl;
+
     this.adblockUrl = extraConfig.adblockUrl;
+
+    this.excludeUrlPaths = extraConfig.excludeUrlPaths;
 
     this.prefix = prefixes.main;
 
@@ -147,6 +155,26 @@ export class Collection {
 
     if (!this.noPostToGet) {
       requestURL = await request.convertPostToGet();
+    }
+
+    if (
+      request.isProxyOrigin &&
+      this.proxyHomePageUrl &&
+      request.proxyOrigin &&
+      requestURL.startsWith(request.proxyOrigin)
+    ) {
+      const url = new URL(requestURL);
+      if (url.pathname === "/") {
+        return fetch(this.proxyHomePageUrl, { mode: "no-cors" });
+      }
+    }
+
+    if (this.excludeUrlPaths?.length) {
+      for (const exclude of this.excludeUrlPaths) {
+        if (requestURL.startsWith(exclude)) {
+          return notFound(request.request);
+        }
+      }
     }
 
     // exact or fuzzy match

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,7 @@ export type ExtraConfig = {
 
   liveRedirectOnNotFound?: boolean;
   adblockUrl?: string;
+  excludeUrlPaths?: string[];
 
   proxyTLD?: string;
   localTLD?: string;
@@ -185,6 +186,8 @@ export type ExtraConfig = {
   archivePrefix?: string;
   archiveMod?: string;
   isLive?: boolean;
+
+  proxyHomePageUrl?: string;
 };
 
 export type CollConfig = {


### PR DESCRIPTION
- override homepage in proxy mode via 'proxyHomePageUrl' (proxy mode only)
- exclude URLs by prefix (proxy and default rewriting mode) via 'excludeUrlPaths'
- bump to 2.26.2