### PR TITLE
url query limit per-args:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "main": "index.js",
   "type": "module",
   "exports": {

--- a/src/cdxloader.ts
+++ b/src/cdxloader.ts
@@ -214,16 +214,25 @@ class CDXFromWARCLoader extends WARCLoader {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         cdx.method,
       );
-      let maxSize;
       // for JS/JSON responses, allow slightly larger POST methods
-      // otherwise limit to 512 as likely POST will be completely ignored
+      // truncate individual URL query values to 1024
+      // otherwise, limit query string to 512 as likely POST will be completely ignored
       if (mime && LONG_POST_MIMES.includes(mime as string)) {
-        maxSize = MAX_ARG_LEN * 8;
+        try {
+          const parsedUrl = new URL(entry.url);
+          for (const [key, value] of parsedUrl.searchParams) {
+            if (value.length > MAX_ARG_LEN) {
+              parsedUrl.searchParams.set(key, value.slice(0, MAX_ARG_LEN));
+            }
+          }
+          entry.url = parsedUrl.href;
+        } catch (_) {
+          entry.url = entry.url.slice(0, MAX_ARG_LEN * 8);
+        }
       } else {
-        maxSize = MAX_ARG_LEN / 2;
-      }
-      if (entry.url.length > maxSize) {
-        entry.url = entry.url.slice(0, maxSize);
+        if (entry.url.length > MAX_ARG_LEN / 2) {
+          entry.url = entry.url.slice(0, MAX_ARG_LEN / 2);
+        }
       }
     }
 


### PR DESCRIPTION
- follow-up to #289, for long-query allowed mime types (eg. json), truncate individual query args instead of entire query string for more accurate matching