### PR TITLE
Remove stub dev-server leftovers

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
   "scripts": {
     "build": "webpack --mode production",
     "build-dev": "NODE_ENV=development webpack --mode development",
-    "start-dev": "webpack-dev-server --mode development",
     "start-live-proxy": "cp dist/sw.js ./examples/live-proxy/sw.js && cd ./examples/live-proxy && ./fetch-adblock.sh && http-server -p 10001",
     "test": "c8 ava",
     "lint:check": "eslint ./src/ ./test/",

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -84,14 +84,6 @@ const mainBuild = {
     outputModule: true,
   },
 
-  devServer: {
-    compress: true,
-    port: 9990,
-    headers: { "Service-Worker-Allowed": "/" },
-    open: false,
-    //publicPath: "/dist/"
-  },
-
   resolve: {
     extensions: [".ts", ".js"],
     plugins: [new TsconfigPathsPlugin()],


### PR DESCRIPTION
The dependency was removed in 3b1cce53501e2ab3500a068cd47ab0f49de9c442, but the config was left in place along with the `yarn start-dev` command.