### PR TITLE
dsruleset: expand mediasource script

### DIFF
--- a/src/rewrite/dsruleset.ts
+++ b/src/rewrite/dsruleset.ts
@@ -113,8 +113,38 @@ export const DEFAULT_RULES: Rules[] = [
 ];
 
 export const DISABLE_MEDIASOURCE_SCRIPT = `\
-  ;Object.defineProperty(MediaSource, "isTypeSupported",\
-  {value: () => false, configurable: false, writable: false});`;
+  ;Object.defineProperty(MediaSource, "isTypeSupported", {
+    value: () => false,
+    configurable: false,
+    writable: false,
+  });
+  const canPlayType = HTMLMediaElement.prototype.canPlayType;
+  Object.defineProperty(HTMLMediaElement.prototype, "canPlayType", {
+    value: (type) => {
+      if (/av01/.test(type)) {
+        return "";
+      } else {
+        return canPlayType.call(this, type);
+      }
+    },
+    configurable: false,
+    writable: false,
+  });
+  const decodingInfo = navigator.mediaCapabilities.decodingInfo;
+  Object.defineProperty(navigator.mediaCapabilities, "decodingInfo", {
+    value: async (configuration) => {
+      if (
+        configuration.video &&
+        /av01/.test(configuration.video.contentType)
+      ) {
+        return { supported: false, smooth: false, powerEfficient: false };
+      } else {
+        return decodingInfo.call(this, configuration);
+      }
+    },
+    configurable: false,
+    writable: false,
+  });`;
 
 export const HTML_ONLY_RULES: Rules[] = [
   {


### PR DESCRIPTION
We currently have a script to try to influence video selection on sites like YouTube, but we haven't thoroughly applied every possible option. There are additional things we can do to try to ensure AV01 codecs don't get picked. This is influenced by several userscripts I've seen, for example https://github.com/HardMeister/yt-vp9-codec-enforcer

I haven't tested this yet since we were working through issues with the live proxy first.

refs https://github.com/webrecorder/browsertrix-behaviors/pull/140