### PR TITLE
Add optional signed URL refresh to FetchRangeLoader

### DIFF
--- a/src/blockloaders.ts
+++ b/src/blockloaders.ts
@@ -13,6 +13,8 @@ import { concatChunks } from "warcio";
 // todo: make configurable
 const HELPER_PROXY = "https://helper-proxy.webrecorder.workers.dev";
 
+const REFRESH_TIMEOUT_MS = 10_000;
+
 export type ResponseAbort = {
   response: Response;
   abort: AbortController | null;
@@ -30,6 +32,8 @@ export type BlockLoaderOpts = {
   extra?: BlockLoaderExtra;
   size?: number;
   blob?: Blob;
+  // endpoint returning {url} to re-resolve an expired signed URL
+  refreshUrlEndpoint?: string;
 };
 
 // ===========================================================================
@@ -155,17 +159,21 @@ class FetchRangeLoader extends BaseLoader {
   ipfsAPI = null;
   loadingIPFS = null;
   arrayBuffer: ArrayBufferLoader | null = null;
+  refreshUrlEndpoint?: string;
+  refreshing: Promise<boolean> | null = null;
 
   constructor({
     url,
     headers,
     length = null,
     canLoadOnDemand = false,
+    refreshUrlEndpoint,
   }: {
     url: string;
     headers?: Record<string, string> | Headers;
     length?: number | null;
     canLoadOnDemand?: boolean;
+    refreshUrlEndpoint?: string;
   }) {
     super(canLoadOnDemand);
 
@@ -174,6 +182,45 @@ class FetchRangeLoader extends BaseLoader {
     this.length = length;
     this.canLoadOnDemand = canLoadOnDemand;
     this.canDoNegativeRange = true;
+    this.refreshUrlEndpoint = refreshUrlEndpoint;
+  }
+
+  /**
+   * Attempt to re-resolve the source URL when access has been lost (e.g. an
+   * expired signed URL returning 403). Fetches a fresh URL from the refresh
+   * endpoint, updates this.url, and returns true on success; returns false
+   * when no `refreshUrlEndpoint` is configured or the refresh fails.
+   */
+  async refreshUrl(): Promise<boolean> {
+    // coalesce concurrent refreshes
+    this.refreshing ??= this.doRefreshUrl().finally(() => {
+      this.refreshing = null;
+    });
+    return this.refreshing;
+  }
+
+  async doRefreshUrl(): Promise<boolean> {
+    if (!this.refreshUrlEndpoint) {
+      return false;
+    }
+    try {
+      const resp = await fetch(this.refreshUrlEndpoint, {
+        credentials: "include",
+        cache: "no-store",
+        signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
+      });
+      if (!resp.ok) {
+        return false;
+      }
+      const json = await resp.json();
+      if (json.url) {
+        this.url = json.url;
+        return true;
+      }
+    } catch (_) {
+      // ignore, treat as failed refresh
+    }
+    return false;
   }
 
   override async doInitialFetch(
@@ -288,6 +335,23 @@ class FetchRangeLoader extends BaseLoader {
     streaming = false,
     signal: AbortSignal | null = null,
   ): Promise<Uint8Array | ReadableStream<Uint8Array>> {
+    try {
+      return await this._getRange(offset, length, streaming, signal);
+    } catch (e) {
+      // expired signed URL surfaces as AccessDeniedError; re-resolve once and retry
+      if (e instanceof AccessDeniedError && (await this.refreshUrl())) {
+        return await this._getRange(offset, length, streaming, signal);
+      }
+      throw e;
+    }
+  }
+
+  async _getRange(
+    offset: number,
+    length: number,
+    streaming = false,
+    signal: AbortSignal | null = null,
+  ): Promise<Uint8Array | ReadableStream<Uint8Array>> {
     if (this.arrayBuffer) {
       return await this.arrayBuffer.getRange(offset, length, streaming);
     }
@@ -306,7 +370,25 @@ class FetchRangeLoader extends BaseLoader {
 
     try {
       resp = await this.retryFetch(this.url, options);
-    } catch (_) {
+    } catch (e) {
+      // An expired signed URL can be unreadable cross-origin: R2 returns the
+      // auth/expiry error (403 ExpiredRequest) with no Access-Control-Allow-Origin
+      // header, so the browser blocks it and fetch() rejects with an
+      // opaque TypeError instead of resolving with a readable 403. Exclude the
+      // cases that definitely are not an expired URL before treating it as
+      // access-denied and letting getRange() re-sign + retry once:
+      //   - aborts: the caller cancelled, never re-sign/retry
+      //   - retryFetch's 429/503-exhaustion throws a plain Error, not a
+      //     TypeError, so a rate-limit storm falls through to RangeError
+      if (
+        signal?.aborted ||
+        (e instanceof DOMException && e.name === "AbortError")
+      ) {
+        throw e;
+      }
+      if (this.refreshUrlEndpoint && e instanceof TypeError) {
+        throw new AccessDeniedError({ url: this.url, status: 403 });
+      }
       throw new RangeError(this.url);
     }
 

--- a/src/blockloaders.ts
+++ b/src/blockloaders.ts
@@ -32,7 +32,8 @@ export type BlockLoaderOpts = {
   extra?: BlockLoaderExtra;
   size?: number;
   blob?: Blob;
-  // endpoint returning {url} to re-resolve an expired signed URL
+  // endpoint returning {url} to re-resolve an expired signed URL, given the
+  // expiring URL as a `url` query param
   refreshUrlEndpoint?: string;
 };
 
@@ -188,8 +189,9 @@ class FetchRangeLoader extends BaseLoader {
   /**
    * Attempt to re-resolve the source URL when access has been lost (e.g. an
    * expired signed URL returning 403). Fetches a fresh URL from the refresh
-   * endpoint, updates this.url, and returns true on success; returns false
-   * when no `refreshUrlEndpoint` is configured or the refresh fails.
+   * endpoint, passing the expiring URL as a `url` query param so the right
+   * object is re-signed, updates this.url, and returns true on success;
+   * returns false when no `refreshUrlEndpoint` is configured or it fails.
    */
   async refreshUrl(): Promise<boolean> {
     // coalesce concurrent refreshes
@@ -204,7 +206,16 @@ class FetchRangeLoader extends BaseLoader {
       return false;
     }
     try {
-      const resp = await fetch(this.refreshUrlEndpoint, {
+      // Identify which object to re-sign: a multi-WACZ collection attaches the
+      // same endpoint to every file's loader, so the endpoint can't know which
+      // file expired unless it's told.
+      // `location` is typed as always-present but is absent outside a
+      // worker/window, so a relative endpoint only resolves in one.
+      const base = (globalThis as { location?: { href: string } }).location
+        ?.href;
+      const endpoint = new URL(this.refreshUrlEndpoint, base);
+      endpoint.searchParams.set("url", this.url);
+      const resp = await fetch(endpoint.href, {
         credentials: "include",
         cache: "no-store",
         signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -343,6 +343,7 @@ export class CollectionLoader {
           headers: config.headers!,
           size: config.size!,
           extra: config.extra!,
+          refreshUrlEndpoint: config.extraConfig?.refreshUrlEndpoint,
         });
         store = new RemoteSourceArchiveDB(
           config.dbname,
@@ -367,6 +368,7 @@ export class CollectionLoader {
           url: config.loadUrl || config.sourceUrl,
           headers: config.headers,
           extra: config.extra,
+          refreshUrlEndpoint: config.extraConfig?.refreshUrlEndpoint,
         });
         store = new MultiWACZ(
           config as WACZCollConfig,
@@ -740,6 +742,7 @@ export class WorkerLoader extends CollectionLoader {
         size: file.size,
         extra: config.extra,
         blob: file.blob,
+        refreshUrlEndpoint: config.extraConfig?.refreshUrlEndpoint,
       });
 
       if (file.loadEager) {
@@ -755,6 +758,7 @@ export class WorkerLoader extends CollectionLoader {
           headers: config.headers,
           size: file.size,
           extra,
+          refreshUrlEndpoint: config.extraConfig?.refreshUrlEndpoint,
         });
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,9 @@ export type ExtraConfig = {
   isLive?: boolean;
 
   proxyHomePageUrl?: string;
+
+  // endpoint returning {url} to re-resolve an expired signed source URL
+  refreshUrlEndpoint?: string;
 };
 
 export type CollConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -191,7 +191,9 @@ export type ExtraConfig = {
 
   proxyHomePageUrl?: string;
 
-  // endpoint returning {url} to re-resolve an expired signed source URL
+  // endpoint returning {url} to re-resolve an expired signed source URL.
+  // The expiring URL is passed as a `url` query param: a multi-WACZ collection
+  // shares one endpoint across every file, so it must be told which to re-sign.
   refreshUrlEndpoint?: string;
 };
 

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -1600,6 +1600,9 @@ export class MultiWACZ
   }
 
   async createLoader(opts: BlockLoaderOpts): Promise<BaseLoader> {
-    return await createLoader(opts);
+    return await createLoader({
+      refreshUrlEndpoint: this.config.extraConfig?.refreshUrlEndpoint,
+      ...opts,
+    });
   }
 }

--- a/test/blockLoaderRefresh.ts
+++ b/test/blockLoaderRefresh.ts
@@ -1,0 +1,241 @@
+import test from "ava";
+
+import { createLoader } from "../src/blockloaders.js";
+import { AccessDeniedError, RangeError } from "../src/utils.js";
+
+const OLD_URL = "https://r2.example/coll.wacz?sig=expired";
+const NEW_URL = "https://r2.example/coll.wacz?sig=fresh";
+const REFRESH_ENDPOINT = "https://app.example/resign";
+const PAYLOAD = new Uint8Array([1, 2, 3]);
+
+type FetchCall = { url: string; range: string | null };
+
+// How the expired (old) URL fails when fetched:
+//  - "resolve403":      fetch() resolves with a readable 403 (same-origin, or a
+//                       store that puts CORS headers on the error response).
+//  - "rejectTypeError": fetch() rejects with a TypeError — the real R2 case,
+//                       where the expiry 403 carries no CORS headers so the
+//                       browser blocks it and the status is unreadable.
+//  - "rejectPlainError": a non-fetch failure reaching the same catch, e.g.
+//                       retryFetch giving up after 429/503 (throws a plain
+//                       Error, not a TypeError).
+type OldUrlMode = "resolve403" | "rejectTypeError" | "rejectPlainError";
+
+// Install a fetch stub that fails the expired URL, hands back a fresh URL from
+// the refresh endpoint, and serves a 206 range from the fresh URL. Set
+// refreshFails to make the refresh endpoint itself reject, as AbortSignal.timeout
+// does when the endpoint hangs past REFRESH_TIMEOUT_MS.
+function installFetchStub({
+  oldUrl = "resolve403",
+  refreshFails = false,
+}: { oldUrl?: OldUrlMode; refreshFails?: boolean } = {}) {
+  const calls: FetchCall[] = [];
+  const orig = globalThis.fetch;
+
+  globalThis.fetch = (async (url: string, opts?: RequestInit) => {
+    const headers = new Headers(opts?.headers);
+    calls.push({ url, range: headers.get("Range") });
+
+    // emulate fetch() rejecting on an already-aborted signal
+    if (opts?.signal?.aborted) {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }
+
+    if (url === REFRESH_ENDPOINT) {
+      if (refreshFails) {
+        throw new DOMException("The operation timed out.", "TimeoutError");
+      }
+      return new Response(JSON.stringify({ url: NEW_URL }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (url === OLD_URL) {
+      switch (oldUrl) {
+        case "rejectTypeError":
+          throw new TypeError("Failed to fetch");
+        case "rejectPlainError":
+          throw new Error("retryFetch failed");
+        default:
+          return new Response(null, { status: 403 });
+      }
+    }
+    if (url === NEW_URL) {
+      return new Response(PAYLOAD, {
+        status: 206,
+        headers: { "Content-Range": `bytes 0-2/3` },
+      });
+    }
+    return new Response(null, { status: 404 });
+  }) as typeof fetch;
+
+  return { calls, restore: () => (globalThis.fetch = orig) };
+}
+
+test.serial(
+  "getRange refreshes a readable (403) signed URL and retries seamlessly",
+  async (t) => {
+    const { calls, restore } = installFetchStub();
+    try {
+      const loader = await createLoader({
+        url: OLD_URL,
+        refreshUrlEndpoint: REFRESH_ENDPOINT,
+      });
+
+      const res = (await loader.getRange(0, 3, false)) as Uint8Array;
+
+      t.deepEqual(Array.from(res), [1, 2, 3]);
+
+      const urls = calls.map((c) => c.url);
+      // expired URL tried first, then the refresh endpoint, then the fresh URL
+      t.deepEqual(urls, [OLD_URL, REFRESH_ENDPOINT, NEW_URL]);
+    } finally {
+      restore();
+    }
+  },
+);
+
+test.serial(
+  "getRange refreshes an opaque (fetch-rejecting) 403 and retries seamlessly",
+  async (t) => {
+    // The real R2 case: the expiry 403 has no CORS headers, so fetch() rejects
+    // with an opaque TypeError rather than resolving with a readable 403.
+    const { calls, restore } = installFetchStub({ oldUrl: "rejectTypeError" });
+    try {
+      const loader = await createLoader({
+        url: OLD_URL,
+        refreshUrlEndpoint: REFRESH_ENDPOINT,
+      });
+
+      const res = (await loader.getRange(0, 3, false)) as Uint8Array;
+
+      t.deepEqual(Array.from(res), [1, 2, 3]);
+      t.deepEqual(
+        calls.map((c) => c.url),
+        [OLD_URL, REFRESH_ENDPOINT, NEW_URL],
+      );
+    } finally {
+      restore();
+    }
+  },
+);
+
+test.serial(
+  "getRange does not re-sign a request the caller aborted",
+  async (t) => {
+    const { calls, restore } = installFetchStub({ oldUrl: "rejectTypeError" });
+    try {
+      const loader = await createLoader({
+        url: OLD_URL,
+        refreshUrlEndpoint: REFRESH_ENDPOINT,
+      });
+
+      const controller = new AbortController();
+      controller.abort();
+
+      let caught: unknown;
+      try {
+        await loader.getRange(0, 3, false, controller.signal);
+      } catch (e) {
+        caught = e;
+      }
+
+      // the abort is surfaced unchanged, not masked as access-denied...
+      t.true(caught instanceof DOMException && caught.name === "AbortError");
+      // ...and no re-sign was attempted
+      t.false(calls.some((c) => c.url === REFRESH_ENDPOINT));
+    } finally {
+      restore();
+    }
+  },
+);
+
+test.serial(
+  "getRange does not re-sign on a non-fetch (non-TypeError) failure",
+  async (t) => {
+    // e.g. retryFetch exhausting its 429/503 retries throws a plain Error; that
+    // must surface as RangeError, not trigger a spurious re-sign.
+    const { calls, restore } = installFetchStub({ oldUrl: "rejectPlainError" });
+    try {
+      const loader = await createLoader({
+        url: OLD_URL,
+        refreshUrlEndpoint: REFRESH_ENDPOINT,
+      });
+
+      let caught: unknown;
+      try {
+        await loader.getRange(0, 3, false);
+      } catch (e) {
+        caught = e;
+      }
+
+      t.true(caught instanceof RangeError);
+      t.false(caught instanceof AccessDeniedError);
+      t.false(calls.some((c) => c.url === REFRESH_ENDPOINT));
+    } finally {
+      restore();
+    }
+  },
+);
+
+test.serial(
+  "getRange without a refresh endpoint surfaces AccessDeniedError on 403",
+  async (t) => {
+    const { calls, restore } = installFetchStub();
+    try {
+      const loader = await createLoader({ url: OLD_URL });
+
+      // Catch locally: AccessDeniedError.info carries a Response, which ava
+      // cannot structured-clone across its worker channel if handed to it.
+      let caught: unknown;
+      try {
+        await loader.getRange(0, 3, false);
+      } catch (e) {
+        caught = e;
+      }
+      t.true(caught instanceof AccessDeniedError);
+
+      // only the expired URL is hit; no refresh attempted
+      t.deepEqual(
+        calls.map((c) => c.url),
+        [OLD_URL],
+      );
+    } finally {
+      restore();
+    }
+  },
+);
+
+test.serial(
+  "getRange surfaces the original error when the refresh endpoint fails",
+  async (t) => {
+    // A hung endpoint rejects via AbortSignal.timeout; the failed refresh must
+    // surface the original AccessDeniedError, not hang or retry the range.
+    const { calls, restore } = installFetchStub({
+      oldUrl: "rejectTypeError",
+      refreshFails: true,
+    });
+    try {
+      const loader = await createLoader({
+        url: OLD_URL,
+        refreshUrlEndpoint: REFRESH_ENDPOINT,
+      });
+
+      let caught: unknown;
+      try {
+        await loader.getRange(0, 3, false);
+      } catch (e) {
+        caught = e;
+      }
+
+      t.true(caught instanceof AccessDeniedError);
+      // refresh was attempted but the fresh URL was never fetched
+      t.deepEqual(
+        calls.map((c) => c.url),
+        [OLD_URL, REFRESH_ENDPOINT],
+      );
+    } finally {
+      restore();
+    }
+  },
+);

--- a/test/blockLoaderRefresh.ts
+++ b/test/blockLoaderRefresh.ts
@@ -8,6 +8,25 @@ const NEW_URL = "https://r2.example/coll.wacz?sig=fresh";
 const REFRESH_ENDPOINT = "https://app.example/resign";
 const PAYLOAD = new Uint8Array([1, 2, 3]);
 
+// a second file in the same collection, sharing one refresh endpoint
+const OLD_URL_B = "https://r2.example/other.wacz?sig=expired";
+const NEW_URL_B = "https://r2.example/other.wacz?sig=fresh";
+const PAYLOAD_B = new Uint8Array([4, 5, 6]);
+
+// what the endpoint hands back for each expiring URL it's asked about
+const RESIGNED: Record<string, string> = {
+  [OLD_URL]: NEW_URL,
+  [OLD_URL_B]: NEW_URL_B,
+};
+const FRESH_BYTES: Record<string, Uint8Array> = {
+  [NEW_URL]: PAYLOAD,
+  [NEW_URL_B]: PAYLOAD_B,
+};
+
+// the refresh endpoint as actually hit: the expiring URL rides along as ?url=
+const resignCall = (expiring: string) =>
+  `${REFRESH_ENDPOINT}?url=${encodeURIComponent(expiring)}`;
+
 type FetchCall = { url: string; range: string | null };
 
 // How the expired (old) URL fails when fetched:
@@ -41,16 +60,22 @@ function installFetchStub({
       throw new DOMException("The operation was aborted.", "AbortError");
     }
 
-    if (url === REFRESH_ENDPOINT) {
+    if (url.startsWith(REFRESH_ENDPOINT)) {
       if (refreshFails) {
         throw new DOMException("The operation timed out.", "TimeoutError");
       }
-      return new Response(JSON.stringify({ url: NEW_URL }), {
+      // re-sign only the object the caller named, as a real endpoint would
+      const expiring = new URL(url).searchParams.get("url");
+      const fresh = expiring ? RESIGNED[expiring] : undefined;
+      if (!fresh) {
+        return new Response(null, { status: 400 });
+      }
+      return new Response(JSON.stringify({ url: fresh }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
     }
-    if (url === OLD_URL) {
+    if (url === OLD_URL || url === OLD_URL_B) {
       switch (oldUrl) {
         case "rejectTypeError":
           throw new TypeError("Failed to fetch");
@@ -60,8 +85,9 @@ function installFetchStub({
           return new Response(null, { status: 403 });
       }
     }
-    if (url === NEW_URL) {
-      return new Response(PAYLOAD, {
+    const bytes = FRESH_BYTES[url];
+    if (bytes) {
+      return new Response(bytes, {
         status: 206,
         headers: { "Content-Range": `bytes 0-2/3` },
       });
@@ -88,7 +114,7 @@ test.serial(
 
       const urls = calls.map((c) => c.url);
       // expired URL tried first, then the refresh endpoint, then the fresh URL
-      t.deepEqual(urls, [OLD_URL, REFRESH_ENDPOINT, NEW_URL]);
+      t.deepEqual(urls, [OLD_URL, resignCall(OLD_URL), NEW_URL]);
     } finally {
       restore();
     }
@@ -112,7 +138,7 @@ test.serial(
       t.deepEqual(Array.from(res), [1, 2, 3]);
       t.deepEqual(
         calls.map((c) => c.url),
-        [OLD_URL, REFRESH_ENDPOINT, NEW_URL],
+        [OLD_URL, resignCall(OLD_URL), NEW_URL],
       );
     } finally {
       restore();
@@ -143,7 +169,7 @@ test.serial(
       // the abort is surfaced unchanged, not masked as access-denied...
       t.true(caught instanceof DOMException && caught.name === "AbortError");
       // ...and no re-sign was attempted
-      t.false(calls.some((c) => c.url === REFRESH_ENDPOINT));
+      t.false(calls.some((c) => c.url.startsWith(REFRESH_ENDPOINT)));
     } finally {
       restore();
     }
@@ -171,7 +197,7 @@ test.serial(
 
       t.true(caught instanceof RangeError);
       t.false(caught instanceof AccessDeniedError);
-      t.false(calls.some((c) => c.url === REFRESH_ENDPOINT));
+      t.false(calls.some((c) => c.url.startsWith(REFRESH_ENDPOINT)));
     } finally {
       restore();
     }
@@ -207,6 +233,42 @@ test.serial(
 );
 
 test.serial(
+  "each file in a multi-WACZ collection re-signs its own URL, not a sibling's",
+  async (t) => {
+    // MultiWACZ gives every inner file's loader the same refreshUrlEndpoint, so
+    // the endpoint only knows which object to re-sign because the expiring URL
+    // is passed to it. Without that, one file could adopt another file's bytes.
+    const { calls, restore } = installFetchStub({ oldUrl: "rejectTypeError" });
+    try {
+      const [loaderA, loaderB] = await Promise.all([
+        createLoader({ url: OLD_URL, refreshUrlEndpoint: REFRESH_ENDPOINT }),
+        createLoader({ url: OLD_URL_B, refreshUrlEndpoint: REFRESH_ENDPOINT }),
+      ]);
+
+      const [resA, resB] = (await Promise.all([
+        loaderA.getRange(0, 3, false),
+        loaderB.getRange(0, 3, false),
+      ])) as Uint8Array[];
+
+      // each loader ends up with its own file's bytes
+      t.deepEqual(Array.from(resA), [1, 2, 3]);
+      t.deepEqual(Array.from(resB), [4, 5, 6]);
+
+      // and each asked the shared endpoint about its own expiring URL
+      const resigns = calls
+        .map((c) => c.url)
+        .filter((u) => u.startsWith(REFRESH_ENDPOINT));
+      t.deepEqual(
+        resigns.sort(),
+        [resignCall(OLD_URL), resignCall(OLD_URL_B)].sort(),
+      );
+    } finally {
+      restore();
+    }
+  },
+);
+
+test.serial(
   "getRange surfaces the original error when the refresh endpoint fails",
   async (t) => {
     // A hung endpoint rejects via AbortSignal.timeout; the failed refresh must
@@ -232,7 +294,7 @@ test.serial(
       // refresh was attempted but the fresh URL was never fetched
       t.deepEqual(
         calls.map((c) => c.url),
-        [OLD_URL, REFRESH_ENDPOINT],
+        [OLD_URL, resignCall(OLD_URL)],
       );
     } finally {
       restore();


### PR DESCRIPTION
#### Summary
Long-lived replay sessions using a single signed WACZ URL (e.g. an S3/R2 pre-signed URL) can outlive the signature expiry. Once the signed WACZ URL expires, range requests return 403 and replay breaks with no recovery without a browser refresh (for a single-file WACZ the existing retryLoad/checkUpdates recovery returns early on rootSourceType !== "json").

This PR introduces an optional refresh endpoint config `refreshUrlEndpoint` to acquire a freshly signed url. This functionality supports [Conifer's twilight service](https://blog.conifer.rhizome.org/2025/12/15/twilight-announcement.html) using replayweb.page with WACZ files stored on Cloudflare's R2 storage provider.

#### Changes
Add an optional `re.freshUrlEndpoint` to obtain a freshly signed URL and retry transparently:
- FetchRangeLoader.refreshUrl(): returns false when no `refreshUrlEndpoint` is set, so unconfigured loaders are unaffected.
- On AccessDeniedError, GET refreshUrlEndpoint (credentials: "include", no-store), swap this.url to the returned {url}, and retry the range once. Concurrent refreshes are coalesced via a shared promise.
- A cross-origin 403 from R2 carries no CORS headers, so `fetch()` rejects rather than returning a response; when a refresh endpoint is set, treat that rejection as access-denied so the retry can fire.
- Thread refreshUrlEndpoint through ExtraConfig -> BlockLoaderOpts and every loader creation site (CollectionLoader, WorkerLoader, MultiWACZ.createLoader).
