### PR TITLE
fix: avoid catching `let/const location =` calls

### DIFF
--- a/src/rewrite/jsrewriter.ts
+++ b/src/rewrite/jsrewriter.ts
@@ -151,6 +151,11 @@ const createJSRules: () => Rule[] = () => {
     // rewriting .postMessage -> __WB_pmw(self).postMessage
     [/\.postMessage\b\(/, addPrefix(".__WB_pmw(self)")],
 
+    // Avoid doing the below rewrite for `let/const` assignments,
+    // which will break the scoping
+    // See: https://github.com/webrecorder/wabac.js/issues/336
+    [/(?:let|const)\s+location\s*=/, (x: string) => x],
+
     // rewriting 'location = ' to custom expression '(...).href =' assignment
     [
       /(?:^|[^$.+*/%^-])\s?\blocation\b\s*[=]\s*(?![\s\d=>])/,

--- a/test/rewriteJS.ts
+++ b/test/rewriteJS.ts
@@ -181,10 +181,28 @@ test(
 );
 
 // Ensure these *don't* get rewritten
-test(rewriteJSWrapped, "const location = http://example.com/");
-test(rewriteJSWrapped, "let location = http://example.com/");
+test(
+  rewriteJSWrapped,
+  'function() { const location = "http://example.com/" }',
+  "",
+);
+test(
+  rewriteJSWrapped,
+  'function() { let location = "http://example.com/"; }',
+  "",
+);
 
-test(rewriteJSWrapped, 'location => "http://example.com/"');
+test(rewriteJSWrapped, "function() { const location = foo.location }", "");
+test(rewriteJSWrapped, "function() { const location = window.location }", "");
+
+// this. is still rewritten
+test(
+  rewriteJSWrapped,
+  "function() { const location = this.location; }",
+  "function() { const location = _____WB$wombat$check$this$function_____(this).location; }",
+);
+
+test(rewriteJSWrapped, 'location => "http://example.com/"', "");
 
 // acorn fails here, but is ignorable
 test(

--- a/test/rewriteJS.ts
+++ b/test/rewriteJS.ts
@@ -180,6 +180,10 @@ test(
   "location = ((self.__WB_check_loc && self.__WB_check_loc(location, arguments)) || {}).maybeHref = http://example.com/",
 );
 
+// Ensure these *don't* get rewritten
+test(rewriteJSWrapped, "const location = http://example.com/");
+test(rewriteJSWrapped, "let location = http://example.com/");
+
 test(rewriteJSWrapped, 'location => "http://example.com/"');
 
 // acorn fails here, but is ignorable


### PR DESCRIPTION
This was inappropriately being rewritten into something invalid.

Fixes #336.