### PR TITLE
idx read: add additional line

### DIFF
--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -685,7 +685,7 @@ export class MultiWACZ
       }
     }
 
-    // Added to mitigate issue from off-by-1 error in some WACZ CDX, 
+    // Added to mitigate issue from off-by-1 error in some WACZ CDX,
     // (https://github.com/webrecorder/browsertrix-crawler/issues/1121)
     // in rare circumstances, requires reading the next block to obtain the CDX.
     for await (const cursor of tx.store.iterate(

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -685,7 +685,9 @@ export class MultiWACZ
       }
     }
 
-    // Add one more value from the surt
+    // Added to mitigate issue from off-by-1 error in some WACZ CDX, 
+    // (https://github.com/webrecorder/browsertrix-crawler/issues/1121)
+    // in rare circumstances, requires reading the next block to obtain the CDX.
     for await (const cursor of tx.store.iterate(
       IDBKeyRange.lowerBound([waczname, surt]),
       "next",

--- a/src/wacz/multiwacz.ts
+++ b/src/wacz/multiwacz.ts
@@ -685,6 +685,23 @@ export class MultiWACZ
       }
     }
 
+    // Add one more value from the surt
+    for await (const cursor of tx.store.iterate(
+      IDBKeyRange.lowerBound([waczname, surt]),
+      "next",
+    )) {
+      const value = cursor.value as IDXLine | null;
+
+      if (!value || value.waczname !== waczname) {
+        break;
+      }
+
+      if (values.indexOf(value) === -1) {
+        values.push(value);
+      }
+      break;
+    }
+
     await tx.done;
 
     const cdxloaders: Promise<void>[] = [];


### PR DESCRIPTION
idx read: to account for possible off-by-1 error, read the 'next' idx line from the matching key
mitigates issues discovered in webrecorder/browsertrix-crawler#1121 for existing WACZ files.