### PR TITLE
replay: correctly mark when a page is missing due to deps

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -1,3 +1,4 @@
+import { OriginalRecordMissingException } from "./remotearchivedb";
 import { ProxyRewriter, Rewriter, TO_MP } from "./rewrite";
 import { DISABLE_MEDIASOURCE_SCRIPT } from "./rewrite/dsruleset";
 
@@ -218,6 +219,19 @@ export class Collection {
         }
       }
     } catch (e) {
+      // If we couldn't load this due to a missing dependency,
+      // we're not going to be able to do anything else;
+      // immediately serve up a page informing the user
+      if (e instanceof OriginalRecordMissingException) {
+        return notFoundByTypeResponse(
+          request.request,
+          requestURL,
+          requestTS,
+          this.liveRedirectOnNotFound,
+          e.cdx.status,
+          "This page is marked as a duplicate but the original page could not be found.",
+        );
+      }
       if (await handleAuthNeeded(e, this.config)) {
         return notFound(
           request.request,

--- a/src/remotearchivedb.ts
+++ b/src/remotearchivedb.ts
@@ -26,6 +26,16 @@ export type Opts = ADBOpts & {
   depth?: number;
 };
 
+export class OriginalRecordMissingException extends Error {
+  cdx: ResourceEntry;
+
+  constructor(msg: string, cdx: ResourceEntry) {
+    super(msg);
+
+    this.cdx = cdx;
+  }
+}
+
 // ===========================================================================
 export abstract class OnDemandPayloadArchiveDB extends ArchiveDB {
   noCache: boolean;
@@ -156,8 +166,13 @@ export abstract class OnDemandPayloadArchiveDB extends ArchiveDB {
         remote.origTS || 0,
         newOpts,
       );
+      // This case can occur if we're missing the original record,
+      // for example if we've loaded a WACZ without its dependencies.
       if (!origResult) {
-        return null;
+        throw new OriginalRecordMissingException(
+          `Encountered revisit record but unable to locate original record for ${remote.origURL}`,
+          cdx,
+        );
       }
 
       const depth = opts.depth || 0;


### PR DESCRIPTION
This occurs when we find a revisit record for a page but the record that revisit points to is missing from the WACZ. This can occur if deduplication was enabled and a WACZ for a later run is replayed without its dependencies.

Sample "not found" page:

<img width="779" height="201" alt="image" src="https://github.com/user-attachments/assets/0c75d1f4-ff1a-4429-9703-f31a7b53093f" />

Fixes webrecorder/replayweb.page#483.