### PR TITLE
not found page improvements:

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -228,7 +228,7 @@ export class Collection {
           requestURL,
           requestTS,
           this.liveRedirectOnNotFound,
-          "archive-missing-original",
+          "missingOriginal",
           e.cdx.status,
           "Original Archived Page Missing",
           "This page is marked as a duplicate but the original page is missing from the archive or has been removed.",

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -228,8 +228,10 @@ export class Collection {
           requestURL,
           requestTS,
           this.liveRedirectOnNotFound,
+          "archive-missing-original",
           e.cdx.status,
-          "This page is marked as a duplicate but the original page could not be found.",
+          "Original Archived Page Missing",
+          "This page is marked as a duplicate but the original page is missing from the archive or has been removed.",
         );
       }
       if (await handleAuthNeeded(e, this.config)) {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -230,8 +230,6 @@ export class Collection {
           this.liveRedirectOnNotFound,
           "missingOriginalForDupe",
           e.cdx.status,
-          "Original Archived Page Missing",
-          "This page is marked as a duplicate but the original page is missing from the archive or has been removed.",
         );
       }
       if (await handleAuthNeeded(e, this.config)) {

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -228,7 +228,7 @@ export class Collection {
           requestURL,
           requestTS,
           this.liveRedirectOnNotFound,
-          "missingOriginal",
+          "missingOriginalForDupe",
           e.cdx.status,
           "Original Archived Page Missing",
           "This page is marked as a duplicate but the original page is missing from the archive or has been removed.",

--- a/src/notfound.ts
+++ b/src/notfound.ts
@@ -5,7 +5,7 @@ import DEFAULT_ERROR_HTML from "./templates/notFound.html";
 let notFoundHtml = "";
 
 // Possible reasons for not found error:
-export type NotFoundReason = "notFound" | "missingOriginal";
+export type NotFoundReason = "notFound" | "missingOriginalForDupe";
 
 export async function setNotFoundTemplate(url: string) {
   try {

--- a/src/notfound.ts
+++ b/src/notfound.ts
@@ -5,7 +5,7 @@ import DEFAULT_ERROR_HTML from "./templates/notFound.html";
 let notFoundHtml = "";
 
 // Possible reasons for not found error:
-export type NotFoundReason = "archive-not-found" | "archive-missing-original";
+export type NotFoundReason = "notFound" | "missingOriginal";
 
 export async function setNotFoundTemplate(url: string) {
   try {
@@ -22,7 +22,7 @@ export function notFound(request: Request, msg?: string, status = 404) {
     request.url,
     "",
     false,
-    "archive-not-found",
+    "notFound",
     status,
     msg,
   );
@@ -33,7 +33,7 @@ export function notFoundByTypeResponse(
   requestURL: string,
   requestTS: string,
   liveRedirectOnNotFound = false,
-  reason: NotFoundReason = "archive-not-found",
+  reason: NotFoundReason = "notFound",
   status = 404,
   title?: string,
   msg?: string,

--- a/src/notfound.ts
+++ b/src/notfound.ts
@@ -35,7 +35,6 @@ export function notFoundByTypeResponse(
   liveRedirectOnNotFound = false,
   reason: NotFoundReason = "notFound",
   status = 404,
-  title?: string,
   msg?: string,
 ) {
   let content: string;
@@ -75,7 +74,6 @@ export function notFoundByTypeResponse(
         requestTS,
         liveRedirectOnNotFound,
         reason,
-        title,
         msg,
       );
       contentType = "text/html; charset=utf-8";
@@ -106,9 +104,23 @@ function getHTMLNotFound(
   requestTS: string,
   liveRedirectOnNotFound: boolean,
   reason: NotFoundReason,
-  title?: string,
   msg?: string,
 ) {
+  let msgDefault, title: string;
+
+  switch (reason) {
+    case "notFound":
+      title = "Archived Page Not Found";
+      msgDefault = "Sorry, this page was not found in this archive:";
+      break;
+
+    case "missingOriginalForDupe":
+      title = "Original Archived Page Missing";
+      msgDefault =
+        "This page is marked as a duplicate but the original page is missing from the archive or has been removed.";
+      break;
+  }
+
   let html = notFoundHtml || DEFAULT_ERROR_HTML;
   html = html.replaceAll("$REQUEST_URL", JSON.stringify(requestURL));
   html = html.replaceAll("$REQUEST_TS", JSON.stringify(requestTS));
@@ -116,14 +128,8 @@ function getHTMLNotFound(
     "$REDIRECT_NOT_FOUND",
     liveRedirectOnNotFound && request.mode === "navigate" ? "1" : "0",
   );
-  html = html.replaceAll(
-    "$TITLE",
-    JSON.stringify(title || "Archived Page Not Found"),
-  );
-  html = html.replaceAll(
-    "$REQUEST_ERR_MSG",
-    JSON.stringify(msg || "Sorry, this page was not found in this archive:"),
-  );
+  html = html.replaceAll("$TITLE", JSON.stringify(title));
+  html = html.replaceAll("$REQUEST_ERR_MSG", JSON.stringify(msg || msgDefault));
   html = html.replaceAll("$REASON", JSON.stringify(reason));
   return html;
 }

--- a/src/notfound.ts
+++ b/src/notfound.ts
@@ -4,6 +4,9 @@ import DEFAULT_ERROR_HTML from "./templates/notFound.html";
 
 let notFoundHtml = "";
 
+// Possible reasons for not found error:
+export type NotFoundReason = "archive-not-found" | "archive-missing-original";
+
 export async function setNotFoundTemplate(url: string) {
   try {
     const resp = await fetch(url);
@@ -14,7 +17,7 @@ export async function setNotFoundTemplate(url: string) {
 }
 
 export function notFound(request: Request, msg?: string, status = 404) {
-  return notFoundByTypeResponse(request, request.url, "", false, status, msg);
+  return notFoundByTypeResponse(request, request.url, "", false, "archive-not-found", status, msg);
 }
 
 export function notFoundByTypeResponse(
@@ -22,7 +25,9 @@ export function notFoundByTypeResponse(
   requestURL: string,
   requestTS: string,
   liveRedirectOnNotFound = false,
+  reason: NotFoundReason = "archive-not-found",
   status = 404,
+  title?: string,
   msg?: string,
 ) {
   let content: string;
@@ -31,17 +36,17 @@ export function notFoundByTypeResponse(
   switch (request.destination as string) {
     case "json":
     case "":
-      content = getJSONNotFound(requestURL, requestTS, msg);
+      content = getJSONNotFound(requestURL, requestTS, reason, msg);
       contentType = "application/json; charset=utf-8";
       break;
 
     case "script":
-      content = getScriptCSSNotFound("Script", requestURL, requestTS, msg);
+      content = getScriptCSSNotFound("Script", requestURL, requestTS, reason, msg);
       contentType = "text/javascript; charset=utf-8";
       break;
 
     case "style":
-      content = getScriptCSSNotFound("CSS", requestURL, requestTS, msg);
+      content = getScriptCSSNotFound("CSS", requestURL, requestTS, reason, msg);
       contentType = "text/css; charset=utf-8";
       break;
 
@@ -55,6 +60,8 @@ export function notFoundByTypeResponse(
         requestURL,
         requestTS,
         liveRedirectOnNotFound,
+        reason,
+        title,
         msg,
       );
       contentType = "text/html; charset=utf-8";
@@ -84,6 +91,8 @@ function getHTMLNotFound(
   requestURL: string,
   requestTS: string,
   liveRedirectOnNotFound: boolean,
+  reason: NotFoundReason,
+  title?: string,
   msg?: string,
 ) {
   let html = notFoundHtml || DEFAULT_ERROR_HTML;
@@ -93,10 +102,12 @@ function getHTMLNotFound(
     "$REDIRECT_NOT_FOUND",
     liveRedirectOnNotFound && request.mode === "navigate" ? "1" : "0",
   );
+  html = html.replaceAll("$TITLE", JSON.stringify(title || "Archived Page Not Found"));
   html = html.replaceAll(
     "$REQUEST_ERR_MSG",
     JSON.stringify(msg || "Sorry, this page was not found in this archive:"),
   );
+  html = html.replaceAll("$REASON", JSON.stringify(reason));
   return html;
 }
 
@@ -104,6 +115,7 @@ function getScriptCSSNotFound(
   type: string,
   requestURL: string,
   requestTS: string,
+  reason: string,
   msg?: string,
 ) {
   return `\
@@ -111,12 +123,13 @@ function getScriptCSSNotFound(
    ${msg || type + " Not Found"}
    URL: ${requestURL}
    TS: ${requestTS}
+   reason: ${reason}
 */
   `;
 }
 
-function getJSONNotFound(URL: string, TS: string, error = "not_found") {
-  return JSON.stringify({ error, URL, TS });
+function getJSONNotFound(URL: string, TS: string, reason: NotFoundReason, error = "not_found") {
+  return JSON.stringify({ error, URL, TS, reason });
 }
 
 export function getProxyNotFoundResponse(url: string, status: number) {

--- a/src/notfound.ts
+++ b/src/notfound.ts
@@ -17,7 +17,15 @@ export async function setNotFoundTemplate(url: string) {
 }
 
 export function notFound(request: Request, msg?: string, status = 404) {
-  return notFoundByTypeResponse(request, request.url, "", false, "archive-not-found", status, msg);
+  return notFoundByTypeResponse(
+    request,
+    request.url,
+    "",
+    false,
+    "archive-not-found",
+    status,
+    msg,
+  );
 }
 
 export function notFoundByTypeResponse(
@@ -41,7 +49,13 @@ export function notFoundByTypeResponse(
       break;
 
     case "script":
-      content = getScriptCSSNotFound("Script", requestURL, requestTS, reason, msg);
+      content = getScriptCSSNotFound(
+        "Script",
+        requestURL,
+        requestTS,
+        reason,
+        msg,
+      );
       contentType = "text/javascript; charset=utf-8";
       break;
 
@@ -102,7 +116,10 @@ function getHTMLNotFound(
     "$REDIRECT_NOT_FOUND",
     liveRedirectOnNotFound && request.mode === "navigate" ? "1" : "0",
   );
-  html = html.replaceAll("$TITLE", JSON.stringify(title || "Archived Page Not Found"));
+  html = html.replaceAll(
+    "$TITLE",
+    JSON.stringify(title || "Archived Page Not Found"),
+  );
   html = html.replaceAll(
     "$REQUEST_ERR_MSG",
     JSON.stringify(msg || "Sorry, this page was not found in this archive:"),
@@ -128,7 +145,12 @@ function getScriptCSSNotFound(
   `;
 }
 
-function getJSONNotFound(URL: string, TS: string, reason: NotFoundReason, error = "not_found") {
+function getJSONNotFound(
+  URL: string,
+  TS: string,
+  reason: NotFoundReason,
+  error = "not_found",
+) {
   return JSON.stringify({ error, URL, TS, reason });
 }
 

--- a/src/templates/notFound.html
+++ b/src/templates/notFound.html
@@ -53,7 +53,8 @@
 
         window.parent.postMessage(
           {
-            wb_type: window.errorReason,
+            wb_type: "archive-not-found",
+            reason: window.errorReason,
             url: window.requestURL,
             ts: $REQUEST_TS,
           },

--- a/src/templates/notFound.html
+++ b/src/templates/notFound.html
@@ -5,10 +5,12 @@
       window.requestURL = $REQUEST_URL;
       window.redirectOnNotFound = $REDIRECT_NOT_FOUND;
       window.errorMsg = $REQUEST_ERR_MSG;
+      window.errorTitle = $TITLE;
+      window.errorReason = $REASON;
     </script>
   </head>
   <body style="font-family: sans-serif">
-    <h2>Archived Page Not Found</h2>
+    <h2 id="title"></h2>
     <p id="msg"></p>
     <p>
       <code id="url" style="word-break: break-all; font-size: larger"></code>
@@ -34,6 +36,9 @@
     </p>
 
     <script>
+      document.querySelector("#title").innerText = window.errorTitle;
+      document.title = window.errorTitle;
+
       document.querySelector("#url").innerText = window.requestURL;
       document.querySelector("#msg").innerText = window.errorMsg;
       document.querySelector("#livelink").href = window.requestURL;
@@ -48,7 +53,7 @@
 
         window.parent.postMessage(
           {
-            wb_type: "archive-not-found",
+            wb_type: window.errorReason,
             url: window.requestURL,
             ts: $REQUEST_TS,
           },


### PR DESCRIPTION
- add NotFoundReason enum, `notFound` or `missingOriginalForDupe`
- pass customize 'title' and 'reason' to templates, allow customizing template based on reason
- pass `reason` to postMessage() event along with wb_type: `archive-not-found` to allow custom handling downstream.