### PR TITLE
use detected content-type from WARC-Identified-Payload-Type if provided:

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -365,6 +365,10 @@ export class Collection {
 
     response = await rewriter.rewrite(response, request);
 
+    if (response.extraOpts?.detectedCT) {
+      response.headers.set("Content-Type", response.extraOpts.detectedCT);
+    }
+
     response.headers.set("Content-Security-Policy", this.csp);
 
     return response;

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -365,10 +365,6 @@ export class Collection {
 
     response = await rewriter.rewrite(response, request);
 
-    if (response.extraOpts?.detectedCT) {
-      response.headers.set("Content-Type", response.extraOpts.detectedCT);
-    }
-
     response.headers.set("Content-Security-Policy", this.csp);
 
     return response;

--- a/src/rewrite/index.ts
+++ b/src/rewrite/index.ts
@@ -279,6 +279,10 @@ export class Rewriter {
       isAjax,
     );
 
+    if (response.extraOpts?.detectedCT) {
+      headers.set("Content-Type", response.extraOpts.detectedCT);
+    }
+
     const encoding = response.headers.get("content-encoding");
     const te = response.headers.get("transfer-encoding");
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,9 @@ export type ExtraOpts = {
 
   // if disabling media source extensions
   disableMSE?: number;
+
+  // if a detected content-type was provided
+  detectedCT?: string;
 };
 
 export type ResourceEntry = {

--- a/src/warcloader.ts
+++ b/src/warcloader.ts
@@ -424,6 +424,14 @@ class WARCLoader extends BaseParser {
       }
     }
 
+    const detectedCT = record.warcHeader("WARC-Identified-Payload-Type");
+    if (detectedCT) {
+      if (!entry.extraOpts) {
+        entry.extraOpts = {};
+      }
+      entry.extraOpts.detectedCT = detectedCT;
+    }
+
     const pageId = record.warcHeader("WARC-Page-ID");
 
     if (pageId) {


### PR DESCRIPTION
- read the header, store in extraOpts.detectedCT for ease of access
- replace existing Content-Type with this value
- part of fix for webrecorder/replayweb.page#541