### PR TITLE
fix: don't pipe through response for missing revisit

### DIFF
--- a/src/collection.ts
+++ b/src/collection.ts
@@ -229,7 +229,7 @@ export class Collection {
           requestTS,
           this.liveRedirectOnNotFound,
           "missingOriginalForDupe",
-          e.cdx.status,
+          404,
         );
       }
       if (await handleAuthNeeded(e, this.config)) {


### PR DESCRIPTION
Theh status in this case is probably non-404, which is correct if we actually had the record to view here btu misleading in the case where we don't have it and are rendering a "not found" page.