### PR TITLE
deps update for 2.27.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@webrecorder/wabac",
-  "version": "2.27.2",
+  "version": "2.27.3",
   "main": "index.js",
   "type": "module",
   "exports": {
@@ -25,7 +25,7 @@
     "@types/js-levenshtein": "^1.1.3",
     "@webrecorder/wombat": "^3.10.8",
     "acorn": "^8.15.0",
-    "auto-js-ipfs": "^2.1.1",
+    "auto-js-ipfs": "^2.3.0",
     "base64-js": "^1.5.1",
     "brotli": "^1.3.3",
     "buffer": "^6.0.3",
@@ -42,7 +42,7 @@
     "path-parser": "^6.1.0",
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
-    "warcio": "^2.4.11"
+    "warcio": "^2.4.12"
   },
   "devDependencies": {
     "@swc-node/register": "^1.10.9",
@@ -80,6 +80,9 @@
     "src/*",
     "dist/*"
   ],
+  "resolutions": {
+    "warcio": "^2.4.12"
+  },
   "scripts": {
     "build": "webpack --mode production",
     "build-dev": "NODE_ENV=development webpack --mode development",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1270,7 +1270,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.4.0"
     "@webrecorder/wombat": "npm:^3.10.8"
     acorn: "npm:^8.15.0"
-    auto-js-ipfs: "npm:^2.1.1"
+    auto-js-ipfs: "npm:^2.3.0"
     ava: "npm:^6.4.1"
     base64-js: "npm:^1.5.1"
     brotli: "npm:^1.3.3"
@@ -1303,7 +1303,7 @@ __metadata:
     tsconfig-paths-webpack-plugin: "npm:^4.1.0"
     tsimp: "npm:^2.0.11"
     typescript: "npm:^5.5.4"
-    warcio: "npm:^2.4.11"
+    warcio: "npm:^2.4.12"
     webpack: "npm:^5.104.1"
     webpack-cli: "npm:^4.8.0"
   languageName: unknown
@@ -1549,10 +1549,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"auto-js-ipfs@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "auto-js-ipfs@npm:2.1.1"
-  checksum: 10c0/a34fc9abfa6dbfd953ca779353b089f07f467d38e6ffdb9408751114e48b42a7e385cd066eb5557318472d1b20a8e56fde2ff6f8743969db498571ea36088563
+"auto-js-ipfs@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "auto-js-ipfs@npm:2.3.0"
+  checksum: 10c0/97e9c14f319a89b9791225cea47bc53884e6915030a04a1cd9551f9cb3d0e5f9b040696f33d94c51166587f1c80b8949b1e99ad5e24355b61e3d5d636f1bc534
   languageName: node
   linkType: hard
 
@@ -5455,9 +5455,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"warcio@npm:^2.4.11":
-  version: 2.4.11
-  resolution: "warcio@npm:2.4.11"
+"warcio@npm:^2.4.12":
+  version: 2.4.12
+  resolution: "warcio@npm:2.4.12"
   dependencies:
     "@types/pako": "npm:^1.0.7"
     "@types/stream-buffers": "npm:^3.0.7"
@@ -5469,7 +5469,7 @@ __metadata:
     yargs: "npm:^17.7.2"
   bin:
     warcio: dist/cli.js
-  checksum: 10c0/7586526e414fc884982cb88780f7552ca2e2344b38c1a828dcdb0ffeeb7d2dcdf506ddae1098de507d2e32289d180ba011a56ab75976d44a9dc2f8cf33e50d84
+  checksum: 10c0/130481784cf5e34f411827a01497e04157369f4b1b39fdfdc95aa8a0ea0092a66d00a1ac3970fd80b18ef4af764cc2f719ea692a3a7d52e6e3d523a589fcaa6f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- update warcio to 2.4.12
- update auto-js-ipfs to 2.3.0 to use same version as AWP
- bump to 2.27.3